### PR TITLE
Add `Observable` and `observableValues`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added typed `Observable` from `core-js-pull`, in PR [#8](https://github.com/compulim/iter-fest/pull/8)
+- Added `observableValues` to convert `Observable` into `AsyncIterableIterator` in PR [#8](https://github.com/compulim/iter-fest/pull/8)
+
 ### Changed
 
 - Bumped dependencies, in PR [#7](https://github.com/compulim/iter-fest/pull/7)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added typed `Observable` from `core-js-pull`, in PR [#8](https://github.com/compulim/iter-fest/pull/8)
+- Added typed `Observable` from `core-js-pure`, in PR [#8](https://github.com/compulim/iter-fest/pull/8)
 - Added `observableValues` to convert `Observable` into `AsyncIterableIterator` in PR [#8](https://github.com/compulim/iter-fest/pull/8)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ for (const value of iteratorToIterable(iterate())) {
 }
 ```
 
+### Typed `Observable`
+
+`Observable` and `Symbol.observable` is re-exported from `core-js-pure` with proper type definitions.
+
 ## Behaviors
 
 ### How this compares to the TC39 proposals?

--- a/README.md
+++ b/README.md
@@ -61,6 +61,20 @@ for (const value of iteratorToIterable(iterate())) {
 
 `Observable` and `Symbol.observable` is re-exported from `core-js-pure` with proper type definitions.
 
+### Converting an `Observable` to `AsyncIterable`
+
+`observableValues` subscribes to an `Observable` and return as `AsyncIterableIterator`.
+
+`Observable` is push-based and `AsyncIterableIterator` is pull-based. Values from `Observable` may push continuously and will be buffered internally. When for-loop break or complete, the iterator will unsubscribe from the `Observable`.
+
+```ts
+const observable = Observable.from([1, 2, 3]);
+
+for await (const value of observableValues(observable)) {
+  console.log(value); // Prints "1", "2", "3".
+}
+```
+
 ## Behaviors
 
 ### How this compares to the TC39 proposals?

--- a/package-lock.json
+++ b/package-lock.json
@@ -10658,12 +10658,16 @@
         "@tsconfig/strictest": "^2.0.5",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.12.13",
+        "core-js-pure": "^3.37.1",
         "esbuild": "^0.21.4",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.2.5",
         "tsup": "^8.0.2",
         "typescript": "^5.4.5"
+      },
+      "peerDependencies": {
+        "core-js-pure": "^3.37.1"
       }
     },
     "packages/pages": {

--- a/packages/integration-test/importDefault.test.ts
+++ b/packages/integration-test/importDefault.test.ts
@@ -21,6 +21,7 @@ import {
   iterableToString,
   iteratorToIterable,
   Observable,
+  observableValues,
   SymbolObservable
 } from 'iter-fest';
 
@@ -107,6 +108,17 @@ test('Observable should work', () => {
   expect(next).toHaveBeenCalledTimes(1);
   expect(next).toHaveBeenNthCalledWith(1, 1);
   expect(complete).toHaveBeenCalledTimes(1);
+});
+
+test('observableValues should work', async () => {
+  const observable = Observable.from([1, 2, 3]);
+  const values = [];
+
+  for await (const value of observableValues(observable)) {
+    values.push(value);
+  }
+
+  expect(values).toEqual([1, 2, 3]);
 });
 
 test('SymbolObservable should work', () => {

--- a/packages/integration-test/importDefault.test.ts
+++ b/packages/integration-test/importDefault.test.ts
@@ -19,7 +19,9 @@ import {
   iterableSome,
   iterableToSpliced,
   iterableToString,
-  iteratorToIterable
+  iteratorToIterable,
+  Observable,
+  SymbolObservable
 } from 'iter-fest';
 
 test('iterableAt should work', () => expect(iterableAt([1, 2, 3].values(), 1)).toBe(2));
@@ -90,3 +92,25 @@ test('iteratorToIterable should work', () =>
       )
     )
   ).toEqual([1, 2, 3]));
+
+test('Observable should work', () => {
+  const next = jest.fn();
+  const complete = jest.fn();
+
+  const observable = new Observable(observer => {
+    observer.next(1);
+    observer.complete();
+  });
+
+  observable.subscribe({ complete, next });
+
+  expect(next).toHaveBeenCalledTimes(1);
+  expect(next).toHaveBeenNthCalledWith(1, 1);
+  expect(complete).toHaveBeenCalledTimes(1);
+});
+
+test('SymbolObservable should work', () => {
+  const observable = new Observable(() => {});
+
+  expect(observable[SymbolObservable]()).toBe(observable);
+});

--- a/packages/integration-test/importNamed.test.ts
+++ b/packages/integration-test/importNamed.test.ts
@@ -19,6 +19,8 @@ import { iterableSome } from 'iter-fest/iterableSome';
 import { iterableToSpliced } from 'iter-fest/iterableToSpliced';
 import { iterableToString } from 'iter-fest/iterableToString';
 import { iteratorToIterable } from 'iter-fest/iteratorToIterable';
+import { Observable } from 'iter-fest/observable';
+import { SymbolObservable } from 'iter-fest/symbolObservable';
 
 test('iterableAt should work', () => expect(iterableAt([1, 2, 3].values(), 1)).toBe(2));
 
@@ -88,3 +90,25 @@ test('iteratorToIterable should work', () =>
       )
     )
   ).toEqual([1, 2, 3]));
+
+test('Observable should work', () => {
+  const next = jest.fn();
+  const complete = jest.fn();
+
+  const observable = new Observable(observer => {
+    observer.next(1);
+    observer.complete();
+  });
+
+  observable.subscribe({ complete, next });
+
+  expect(next).toHaveBeenCalledTimes(1);
+  expect(next).toHaveBeenNthCalledWith(1, 1);
+  expect(complete).toHaveBeenCalledTimes(1);
+});
+
+test('SymbolObservable should work', () => {
+  const observable = new Observable(() => {});
+
+  expect(observable[SymbolObservable]()).toBe(observable);
+});

--- a/packages/integration-test/importNamed.test.ts
+++ b/packages/integration-test/importNamed.test.ts
@@ -20,6 +20,7 @@ import { iterableToSpliced } from 'iter-fest/iterableToSpliced';
 import { iterableToString } from 'iter-fest/iterableToString';
 import { iteratorToIterable } from 'iter-fest/iteratorToIterable';
 import { Observable } from 'iter-fest/observable';
+import { observableValues } from 'iter-fest/observableValues';
 import { SymbolObservable } from 'iter-fest/symbolObservable';
 
 test('iterableAt should work', () => expect(iterableAt([1, 2, 3].values(), 1)).toBe(2));
@@ -105,6 +106,17 @@ test('Observable should work', () => {
   expect(next).toHaveBeenCalledTimes(1);
   expect(next).toHaveBeenNthCalledWith(1, 1);
   expect(complete).toHaveBeenCalledTimes(1);
+});
+
+test('observableValues should work', async () => {
+  const observable = Observable.from([1, 2, 3]);
+  const values = [];
+
+  for await (const value of observableValues(observable)) {
+    values.push(value);
+  }
+
+  expect(values).toEqual([1, 2, 3]);
 });
 
 test('SymbolObservable should work', () => {

--- a/packages/integration-test/requireNamed.test.cjs
+++ b/packages/integration-test/requireNamed.test.cjs
@@ -20,6 +20,7 @@ const { iterableToSpliced } = require('iter-fest/iterableToSpliced');
 const { iterableToString } = require('iter-fest/iterableToString');
 const { iteratorToIterable } = require('iter-fest/iteratorToIterable');
 const { Observable } = require('iter-fest/observable');
+const { observableValues } = require('iter-fest/observableValues');
 const { SymbolObservable } = require('iter-fest/symbolObservable');
 
 test('iterableAt should work', () => expect(iterableAt([1, 2, 3].values(), 1)).toBe(2));
@@ -105,6 +106,17 @@ test('Observable should work', () => {
   expect(next).toHaveBeenCalledTimes(1);
   expect(next).toHaveBeenNthCalledWith(1, 1);
   expect(complete).toHaveBeenCalledTimes(1);
+});
+
+test('observableValues should work', async () => {
+  const observable = Observable.from([1, 2, 3]);
+  const values = [];
+
+  for await (const value of observableValues(observable)) {
+    values.push(value);
+  }
+
+  expect(values).toEqual([1, 2, 3]);
 });
 
 test('SymbolObservable should work', () => {

--- a/packages/integration-test/requireNamed.test.cjs
+++ b/packages/integration-test/requireNamed.test.cjs
@@ -19,6 +19,8 @@ const { iterableSome } = require('iter-fest/iterableSome');
 const { iterableToSpliced } = require('iter-fest/iterableToSpliced');
 const { iterableToString } = require('iter-fest/iterableToString');
 const { iteratorToIterable } = require('iter-fest/iteratorToIterable');
+const { Observable } = require('iter-fest/observable');
+const { SymbolObservable } = require('iter-fest/symbolObservable');
 
 test('iterableAt should work', () => expect(iterableAt([1, 2, 3].values(), 1)).toBe(2));
 
@@ -88,3 +90,25 @@ test('iteratorToIterable should work', () =>
       )
     )
   ).toEqual([1, 2, 3]));
+
+test('Observable should work', () => {
+  const next = jest.fn();
+  const complete = jest.fn();
+
+  const observable = new Observable(observer => {
+    observer.next(1);
+    observer.complete();
+  });
+
+  observable.subscribe({ complete, next });
+
+  expect(next).toHaveBeenCalledTimes(1);
+  expect(next).toHaveBeenNthCalledWith(1, 1);
+  expect(complete).toHaveBeenCalledTimes(1);
+});
+
+test('SymbolObservable should work', () => {
+  const observable = new Observable(() => {});
+
+  expect(observable[SymbolObservable]()).toBe(observable);
+});

--- a/packages/integration-test/requiredDefault.test.cjs
+++ b/packages/integration-test/requiredDefault.test.cjs
@@ -19,7 +19,9 @@ const {
   iterableSome,
   iterableToSpliced,
   iterableToString,
-  iteratorToIterable
+  iteratorToIterable,
+  Observable,
+  SymbolObservable
 } = require('iter-fest');
 
 test('iterableAt should work', () => expect(iterableAt([1, 2, 3].values(), 1)).toBe(2));
@@ -90,3 +92,25 @@ test('iteratorToIterable should work', () =>
       )
     )
   ).toEqual([1, 2, 3]));
+
+test('Observable should work', () => {
+  const next = jest.fn();
+  const complete = jest.fn();
+
+  const observable = new Observable(observer => {
+    observer.next(1);
+    observer.complete();
+  });
+
+  observable.subscribe({ complete, next });
+
+  expect(next).toHaveBeenCalledTimes(1);
+  expect(next).toHaveBeenNthCalledWith(1, 1);
+  expect(complete).toHaveBeenCalledTimes(1);
+});
+
+test('SymbolObservable should work', () => {
+  const observable = new Observable(() => {});
+
+  expect(observable[SymbolObservable]()).toBe(observable);
+});

--- a/packages/integration-test/requiredDefault.test.cjs
+++ b/packages/integration-test/requiredDefault.test.cjs
@@ -21,6 +21,7 @@ const {
   iterableToString,
   iteratorToIterable,
   Observable,
+  observableValues,
   SymbolObservable
 } = require('iter-fest');
 
@@ -107,6 +108,17 @@ test('Observable should work', () => {
   expect(next).toHaveBeenCalledTimes(1);
   expect(next).toHaveBeenNthCalledWith(1, 1);
   expect(complete).toHaveBeenCalledTimes(1);
+});
+
+test('observableValues should work', async () => {
+  const observable = Observable.from([1, 2, 3]);
+  const values = [];
+
+  for await (const value of observableValues(observable)) {
+    values.push(value);
+  }
+
+  expect(values).toEqual([1, 2, 3]);
 });
 
 test('SymbolObservable should work', () => {

--- a/packages/iter-fest/package.json
+++ b/packages/iter-fest/package.json
@@ -216,6 +216,26 @@
         "default": "./dist/iter-fest.iteratorToIterable.js"
       }
     },
+    "./observable": {
+      "import": {
+        "types": "./dist/iter-fest.observable.d.mts",
+        "default": "./dist/iter-fest.observable.mjs"
+      },
+      "require": {
+        "types": "./dist/iter-fest.observable.d.ts",
+        "default": "./dist/iter-fest.observable.js"
+      }
+    },
+    "./symbolObservable": {
+      "import": {
+        "types": "./dist/iter-fest.symbolObservable.d.mts",
+        "default": "./dist/iter-fest.symbolObservable.mjs"
+      },
+      "require": {
+        "types": "./dist/iter-fest.symbolObservable.d.ts",
+        "default": "./dist/iter-fest.symbolObservable.js"
+      }
+    },
     ".": {
       "import": {
         "types": "./dist/iter-fest.d.mts",
@@ -258,6 +278,9 @@
     "url": "https://github.com/compulim/iter-fest/issues"
   },
   "homepage": "https://github.com/compulim/iter-fest#readme",
+  "peerDependencies": {
+    "core-js-pure": "^3.37.1"
+  },
   "devDependencies": {
     "@babel/preset-env": "^7.24.6",
     "@babel/preset-typescript": "^7.24.6",
@@ -266,6 +289,7 @@
     "@tsconfig/strictest": "^2.0.5",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.13",
+    "core-js-pure": "^3.37.1",
     "esbuild": "^0.21.4",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",

--- a/packages/iter-fest/package.json
+++ b/packages/iter-fest/package.json
@@ -226,6 +226,16 @@
         "default": "./dist/iter-fest.observable.js"
       }
     },
+    "./observableValues": {
+      "import": {
+        "types": "./dist/iter-fest.observableValues.d.mts",
+        "default": "./dist/iter-fest.observableValues.mjs"
+      },
+      "require": {
+        "types": "./dist/iter-fest.observableValues.d.ts",
+        "default": "./dist/iter-fest.observableValues.js"
+      }
+    },
     "./symbolObservable": {
       "import": {
         "types": "./dist/iter-fest.symbolObservable.d.mts",

--- a/packages/iter-fest/src/Observable.fromOf.spec.ts
+++ b/packages/iter-fest/src/Observable.fromOf.spec.ts
@@ -7,19 +7,13 @@ import {
   type StartFunction,
   type Subscription
 } from './Observable';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type MockOfFunction<T extends (this: any, ...args: any[]) => any> = jest.Mock<
-  ReturnType<T>,
-  Parameters<T>,
-  ThisParameterType<T>
->;
+import type { JestMockOf } from './private/JestMockOf';
 
 describe('comprehensive', () => {
-  let complete: MockOfFunction<CompleteFunction>;
-  let error: MockOfFunction<ErrorFunction>;
-  let next: MockOfFunction<NextFunction<number>>;
-  let start: MockOfFunction<StartFunction>;
+  let complete: JestMockOf<CompleteFunction>;
+  let error: JestMockOf<ErrorFunction>;
+  let next: JestMockOf<NextFunction<number>>;
+  let start: JestMockOf<StartFunction>;
 
   beforeEach(() => {
     complete = jest.fn();

--- a/packages/iter-fest/src/Observable.fromOf.spec.ts
+++ b/packages/iter-fest/src/Observable.fromOf.spec.ts
@@ -1,0 +1,67 @@
+import {
+  Observable,
+  type CompleteFunction,
+  type ErrorFunction,
+  type NextFunction,
+  type Observer,
+  type StartFunction,
+  type Subscription
+} from './Observable';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MockOfFunction<T extends (this: any, ...args: any[]) => any> = jest.Mock<
+  ReturnType<T>,
+  Parameters<T>,
+  ThisParameterType<T>
+>;
+
+describe('comprehensive', () => {
+  let complete: MockOfFunction<CompleteFunction>;
+  let error: MockOfFunction<ErrorFunction>;
+  let next: MockOfFunction<NextFunction<number>>;
+  let start: MockOfFunction<StartFunction>;
+
+  beforeEach(() => {
+    complete = jest.fn();
+    error = jest.fn();
+    next = jest.fn();
+    start = jest.fn();
+  });
+
+  describe.each([['from' as const], ['of' as const]])('Observable.%s()', type => {
+    let observable: Observable<number>;
+
+    beforeEach(() => {
+      if (type === 'from') {
+        observable = Observable.from<number>([1, 2, 3].values());
+      } else if (type === 'of') {
+        observable = Observable.of<number>(1, 2, 3);
+      }
+    });
+
+    describe.each([['interface' as const], ['functions' as const]])('subscribe via %s', type => {
+      let subscription: Subscription;
+
+      beforeEach(() => {
+        if (type === 'functions') {
+          subscription = observable.subscribe(next, error, complete);
+        } else if (type === 'interface') {
+          subscription = observable.subscribe({ complete, error, next, start } satisfies Observer<number>);
+        }
+      });
+
+      test('subscription.closed should be true', () => expect(subscription).toHaveProperty('closed', true));
+
+      describe('next() should been called', () => {
+        test('3 times', () => expect(next).toHaveBeenCalledTimes(3));
+        test('with values', () => {
+          expect(next).toHaveBeenNthCalledWith(1, 1);
+          expect(next).toHaveBeenNthCalledWith(2, 2);
+          expect(next).toHaveBeenNthCalledWith(3, 3);
+        });
+      });
+
+      test('complete() should have been called once', () => expect(complete).toHaveBeenCalledTimes(1));
+    });
+  });
+});

--- a/packages/iter-fest/src/Observable.spec.ts
+++ b/packages/iter-fest/src/Observable.spec.ts
@@ -1,0 +1,150 @@
+import {
+  Observable,
+  type CompleteFunction,
+  type ErrorFunction,
+  type NextFunction,
+  type Observer,
+  type StartFunction,
+  type SubscriberFunction,
+  type Subscription
+} from './Observable';
+import { SymbolObservable } from './SymbolObservable';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type MockOfFunction<T extends (this: any, ...args: any[]) => any> = jest.Mock<
+  ReturnType<T>,
+  Parameters<T>,
+  ThisParameterType<T>
+>;
+
+describe('comprehensive', () => {
+  let complete: MockOfFunction<CompleteFunction>;
+  let error: MockOfFunction<ErrorFunction>;
+  let next: MockOfFunction<NextFunction<number>>;
+  let observable: Observable<number>;
+  let start: MockOfFunction<StartFunction>;
+  let subscriberFunction: MockOfFunction<SubscriberFunction<number>>;
+  let closeSubscription: MockOfFunction<() => void>;
+
+  beforeEach(() => {
+    closeSubscription = jest.fn();
+    complete = jest.fn();
+    error = jest.fn();
+    next = jest.fn();
+    start = jest.fn();
+    subscriberFunction = jest.fn();
+    subscriberFunction.mockImplementation(() => closeSubscription);
+
+    observable = new Observable<number>(subscriberFunction);
+  });
+
+  describe.each([['interface' as const], ['functions' as const]])('subscribe via %s', type => {
+    let subscription: Subscription;
+
+    beforeEach(() => {
+      if (type === 'functions') {
+        subscription = observable.subscribe(next, error, complete);
+      } else if (type === 'interface') {
+        subscription = observable.subscribe({ complete, error, next, start } satisfies Observer<number>);
+      }
+    });
+
+    if (type === 'interface') {
+      test('start() should be called once', () => expect(start).toHaveBeenCalledTimes(1));
+    }
+
+    test('Symbol.observable should return self', () => expect(observable[SymbolObservable]()).toBe(observable));
+
+    test('closeSubscription() should not be called', () => expect(closeSubscription).not.toHaveBeenCalled());
+    test('subscriberFunction() should be called once', () => expect(subscriberFunction).toHaveBeenCalledTimes(1));
+    test('subscription.closed should return false', () => expect(subscription).toHaveProperty('closed', false));
+
+    describe('when subscription.unsubscribe() is called', () => {
+      beforeEach(() => subscription.unsubscribe());
+
+      test('closeSubscription() should be called once', () => expect(closeSubscription).toHaveBeenCalledTimes(1));
+    });
+
+    describe('when SubscriberFunction.complete() is called', () => {
+      beforeEach(() => subscriberFunction.mock.calls[0]?.[0].complete());
+
+      test('closeSubscription() should be called once', () => expect(closeSubscription).toHaveBeenCalledTimes(1));
+      test('should call Observer.complete() once', () => expect(complete).toHaveBeenCalledTimes(1));
+    });
+
+    describe("when SubscriberFunction.error('artificial') is called", () => {
+      beforeEach(() => subscriberFunction.mock.calls[0]?.[0].error('artificial'));
+
+      describe('should call Observer.error(k)', () => {
+        test('once', () => expect(error).toHaveBeenCalledTimes(1));
+        test('with value "artificial"', () => expect(error).toHaveBeenNthCalledWith(1, 'artificial'));
+      });
+    });
+
+    describe('when SubscriberFunction.next(1) is called', () => {
+      beforeEach(() => subscriberFunction.mock.calls[0]?.[0].next(1));
+
+      describe('should call Observer.next()', () => {
+        test('once', () => expect(next).toHaveBeenCalledTimes(1));
+        test('with value 1', () => expect(next).toHaveBeenNthCalledWith(1, 1));
+      });
+    });
+  });
+
+  describe('when call close() in SubscriberFunction immediately', () => {
+    test('should call start() before complete()', () => {
+      subscriberFunction.mockImplementation(({ complete }) => {
+        expect(start).toHaveBeenCalledTimes(1);
+        expect(complete).not.toHaveBeenCalled();
+
+        complete();
+
+        expect(complete).toHaveBeenCalledTimes(1);
+        expect(complete).toHaveBeenNthCalledWith(1);
+
+        return () => {};
+      });
+
+      observable.subscribe({ complete, error, next, start } satisfies Observer<number>);
+    });
+  });
+
+  describe('when call next(1) in SubscriberFunction immediately', () => {
+    test('should call start() before next()', () => {
+      subscriberFunction.mockImplementation(({ next }) => {
+        expect(start).toHaveBeenCalledTimes(1);
+        expect(next).not.toHaveBeenCalled();
+
+        next(1);
+
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(next).toHaveBeenNthCalledWith(1, 1);
+
+        return () => {};
+      });
+
+      observable.subscribe({ complete, error, next, start } satisfies Observer<number>);
+    });
+  });
+
+  describe('when throw in SubscribeFunction immediately', () => {
+    beforeEach(() => {
+      subscriberFunction.mockImplementation(() => {
+        expect(start).toHaveBeenCalledTimes(1);
+        expect(error).not.toHaveBeenCalled();
+
+        throw new Error('artificial');
+      });
+
+      observable.subscribe({ complete, error, next, start } satisfies Observer<number>);
+    });
+
+    describe('should call error()', () => {
+      test('once', () => expect(error).toHaveBeenCalledTimes(1));
+      test('with the error', () =>
+        expect(() => {
+          throw error.mock.calls[0]?.[0];
+        }).toThrow('artificial'));
+    });
+  });
+});

--- a/packages/iter-fest/src/Observable.spec.ts
+++ b/packages/iter-fest/src/Observable.spec.ts
@@ -9,22 +9,16 @@ import {
   type Subscription
 } from './Observable';
 import { SymbolObservable } from './SymbolObservable';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type MockOfFunction<T extends (this: any, ...args: any[]) => any> = jest.Mock<
-  ReturnType<T>,
-  Parameters<T>,
-  ThisParameterType<T>
->;
+import type { JestMockOf } from './private/JestMockOf';
 
 describe('comprehensive', () => {
-  let complete: MockOfFunction<CompleteFunction>;
-  let error: MockOfFunction<ErrorFunction>;
-  let next: MockOfFunction<NextFunction<number>>;
+  let complete: JestMockOf<CompleteFunction>;
+  let error: JestMockOf<ErrorFunction>;
+  let next: JestMockOf<NextFunction<number>>;
   let observable: Observable<number>;
-  let start: MockOfFunction<StartFunction>;
-  let subscriberFunction: MockOfFunction<SubscriberFunction<number>>;
-  let closeSubscription: MockOfFunction<() => void>;
+  let start: JestMockOf<StartFunction>;
+  let subscriberFunction: JestMockOf<SubscriberFunction<number>>;
+  let closeSubscription: JestMockOf<() => void>;
 
   beforeEach(() => {
     closeSubscription = jest.fn();

--- a/packages/iter-fest/src/Observable.ts
+++ b/packages/iter-fest/src/Observable.ts
@@ -1,0 +1,91 @@
+// @ts-expect-error core-js is not typed.
+import CoreJSObservable from 'core-js-pure/full/observable';
+
+import { SymbolObservable } from './SymbolObservable';
+
+export interface SubscriptionObserver<T> {
+  /** Sends the next value in the sequence */
+  next(value: T): void;
+
+  /** Sends the sequence error */
+  error(errorValue: unknown): void;
+
+  /** Sends the completion notification */
+  complete(): void;
+
+  /** A boolean value indicating whether the subscription is closed */
+  get closed(): boolean;
+}
+
+export interface Subscription {
+  /** Cancels the subscription */
+  unsubscribe(): void;
+
+  /** A boolean value indicating whether the subscription is closed */
+  get closed(): boolean;
+}
+
+export type SubscriberFunction<T> = (observer: SubscriptionObserver<T>) => (() => void) | Subscription | void;
+
+export type CompleteFunction = () => void;
+export type ErrorFunction = (errorValue: unknown) => void;
+export type NextFunction<T> = (value: T) => void;
+export type StartFunction = (subscription: Subscription) => void;
+
+export interface Observer<T> {
+  /** Receives a completion notification */
+  complete?(): void;
+
+  /** Receives the sequence error */
+  error?(errorValue: unknown): void;
+
+  /** Receives the next value in the sequence */
+  next?(value: T): void;
+
+  /** Receives the subscription object when `subscribe` is called */
+  start?(subscription: Subscription): void;
+}
+
+export class Observable<T> extends CoreJSObservable {
+  constructor(subscriber: SubscriberFunction<T>) {
+    super(subscriber);
+  }
+
+  /** Subscribes to the sequence with an observer */
+  subscribe(observer: Observer<T>): Subscription;
+
+  /** Subscribes to the sequence with callbacks */
+  subscribe(
+    onNext: NextFunction<T>,
+    onError?: ErrorFunction | undefined,
+    onComplete?: CompleteFunction | undefined
+  ): Subscription;
+
+  subscribe(
+    observerOrOnNext: Observer<T> | NextFunction<T>,
+    onError?: ErrorFunction | undefined,
+    onComplete?: CompleteFunction | undefined
+  ): Subscription {
+    return super.subscribe(observerOrOnNext, onError, onComplete);
+  }
+
+  /** Returns itself */
+  [SymbolObservable](): Observable<T> {
+    return this;
+  }
+
+  /** Converts items to an Observable */
+  static of<T>(...items: T[]): Observable<T> {
+    return CoreJSObservable.of(...items);
+  }
+
+  /** Converts an iterable to an Observable */
+  static from<T>(iterable: Iterable<T>): Observable<T>;
+
+  /** Converts an observable to an Observable */
+  static from<T>(observable: Observable<T>): Observable<T>;
+
+  static from<T>(iterableOrObservable: Iterable<T> | Observable<T>): Observable<T> {
+    return CoreJSObservable.from(iterableOrObservable);
+  }
+}

--- a/packages/iter-fest/src/SymbolObservable.ts
+++ b/packages/iter-fest/src/SymbolObservable.ts
@@ -1,0 +1,6 @@
+// @ts-expect-error core-js is not typed.
+import CoreJSSymbolObservable from 'core-js-pure/features/symbol/observable';
+
+const SymbolObservable: unique symbol = CoreJSSymbolObservable;
+
+export { SymbolObservable };

--- a/packages/iter-fest/src/index.ts
+++ b/packages/iter-fest/src/index.ts
@@ -1,4 +1,5 @@
 export * from './Observable';
+export * from './SymbolObservable';
 export * from './iterableAt';
 export * from './iterableConcat';
 export * from './iterableEntries';
@@ -20,4 +21,4 @@ export * from './iterableSome';
 export * from './iterableToSpliced';
 export * from './iterableToString';
 export * from './iteratorToIterable';
-export * from './SymbolObservable';
+export * from './observableValues';

--- a/packages/iter-fest/src/index.ts
+++ b/packages/iter-fest/src/index.ts
@@ -1,45 +1,23 @@
-import { iterableAt } from './iterableAt';
-import { iterableConcat } from './iterableConcat';
-import { iterableEntries } from './iterableEntries';
-import { iterableEvery } from './iterableEvery';
-import { iterableFilter } from './iterableFilter';
-import { iterableFind } from './iterableFind';
-import { iterableFindIndex } from './iterableFindIndex';
-import { iterableFindLast } from './iterableFindLast';
-import { iterableFindLastIndex } from './iterableFindLastIndex';
-import { iterableForEach } from './iterableForEach';
-import { iterableIncludes } from './iterableIncludes';
-import { iterableIndexOf } from './iterableIndexOf';
-import { iterableJoin } from './iterableJoin';
-import { iterableKeys } from './iterableKeys';
-import { iterableMap } from './iterableMap';
-import { iterableReduce } from './iterableReduce';
-import { iterableSlice } from './iterableSlice';
-import { iterableSome } from './iterableSome';
-import { iterableToSpliced } from './iterableToSpliced';
-import { iterableToString } from './iterableToString';
-import { iteratorToIterable } from './iteratorToIterable';
-
-export {
-  iterableAt,
-  iterableConcat,
-  iterableEntries,
-  iterableEvery,
-  iterableFilter,
-  iterableFind,
-  iterableFindIndex,
-  iterableFindLast,
-  iterableFindLastIndex,
-  iterableForEach,
-  iterableIncludes,
-  iterableIndexOf,
-  iterableJoin,
-  iterableKeys,
-  iterableMap,
-  iterableReduce,
-  iterableSlice,
-  iterableSome,
-  iterableToSpliced,
-  iterableToString,
-  iteratorToIterable
-};
+export * from './Observable';
+export * from './iterableAt';
+export * from './iterableConcat';
+export * from './iterableEntries';
+export * from './iterableEvery';
+export * from './iterableFilter';
+export * from './iterableFind';
+export * from './iterableFindIndex';
+export * from './iterableFindLast';
+export * from './iterableFindLastIndex';
+export * from './iterableForEach';
+export * from './iterableIncludes';
+export * from './iterableIndexOf';
+export * from './iterableJoin';
+export * from './iterableKeys';
+export * from './iterableMap';
+export * from './iterableReduce';
+export * from './iterableSlice';
+export * from './iterableSome';
+export * from './iterableToSpliced';
+export * from './iterableToString';
+export * from './iteratorToIterable';
+export * from './SymbolObservable';

--- a/packages/iter-fest/src/observableValues.spec.ts
+++ b/packages/iter-fest/src/observableValues.spec.ts
@@ -1,0 +1,122 @@
+import { Observable, type SubscriberFunction, type SubscriptionObserver } from './Observable';
+import { observableValues } from './observableValues';
+import type { JestMockOf } from './private/JestMockOf';
+
+describe('comprehensive', () => {
+  describe('step-by-step', () => {
+    let closeFunction: JestMockOf<() => void>;
+    let iterator: AsyncIterableIterator<number>;
+    let observable: Observable<number>;
+    let observer: SubscriptionObserver<number>;
+    let subscriberFunction: JestMockOf<SubscriberFunction<number>>;
+
+    beforeEach(() => {
+      closeFunction = jest.fn();
+      subscriberFunction = jest.fn().mockImplementation(o => {
+        observer = o;
+
+        return closeFunction;
+      });
+
+      observable = new Observable(subscriberFunction);
+      iterator = observableValues(observable);
+    });
+
+    describe('when iterator.next() is called', () => {
+      let promise: Promise<IteratorResult<number>>;
+
+      beforeEach(() => {
+        promise = iterator.next();
+      });
+
+      test('should not have resolved', () => expect(Promise.race([promise, false])).resolves.toBe(false));
+
+      describe('when observer.complete() is called', () => {
+        beforeEach(() => observer.complete());
+
+        test('iterator.next() should return done', () =>
+          expect(promise).resolves.toEqual({ done: true, value: undefined }));
+      });
+
+      describe('when observer.error() is called', () => {
+        beforeEach(() => observer.error(new Error('artificial')));
+
+        test('iterator.next() should throw', () => expect(promise).rejects.toThrow('artificial'));
+      });
+
+      describe('when observer.next(1) is called', () => {
+        beforeEach(() => observer.next(1));
+
+        test('iterator.next() should return 1', () => expect(promise).resolves.toEqual({ done: false, value: 1 }));
+      });
+    });
+  });
+
+  describe('iterate all at once', () => {
+    let iterator: AsyncIterableIterator<number>;
+    let observable: Observable<number>;
+
+    beforeEach(() => {
+      observable = Observable.from([1, 2, 3]);
+      iterator = observableValues(observable);
+    });
+
+    describe('when iterate', () => {
+      let values: number[];
+
+      beforeEach(async () => {
+        values = [];
+
+        for await (const value of iterator) {
+          values.push(value);
+        }
+      });
+
+      test('should return all values', () => expect(values).toEqual([1, 2, 3]));
+    });
+  });
+
+  test('when for-loop break should unsubscribe', async () => {
+    const closeFunction = jest.fn();
+    const subscriberFunction: JestMockOf<SubscriberFunction<number>> = jest.fn();
+    let observer: SubscriptionObserver<number> | undefined;
+
+    subscriberFunction.mockImplementation(target => {
+      observer = target;
+
+      return closeFunction;
+    });
+
+    const observable = new Observable<number>(subscriberFunction);
+    const values: number[] = [];
+
+    const promise = (async function () {
+      const iterator = observableValues<number>(observable);
+
+      for await (const value of iterator) {
+        values.push(value);
+
+        if (value === 2) {
+          break;
+        }
+      }
+    })();
+
+    expect(observer).not.toBeFalsy();
+
+    if (!observer) {
+      throw new Error();
+    }
+
+    observer.next(1);
+
+    expect(closeFunction).not.toHaveBeenCalled();
+
+    observer.next(2);
+
+    await promise;
+
+    expect(closeFunction).toHaveBeenCalledTimes(1);
+    expect(values).toEqual([1, 2]);
+  });
+});

--- a/packages/iter-fest/src/observableValues.ts
+++ b/packages/iter-fest/src/observableValues.ts
@@ -1,0 +1,69 @@
+import withResolvers from './private/withResolvers';
+
+import { Observable } from './Observable';
+
+const COMPLETE = Symbol('complete');
+const NEXT = Symbol('next');
+const THROW = Symbol('throw');
+
+type Entry<T> = [typeof COMPLETE] | [typeof NEXT, T] | [typeof THROW, unknown];
+
+export function observableValues<T>(observable: Observable<T>): AsyncIterableIterator<T> {
+  const queue: Entry<T>[] = [];
+  let deferred = withResolvers<Entry<T>>();
+
+  const push = (entry: Entry<T>) => {
+    queue.push(entry);
+    deferred.resolve(entry);
+    deferred = withResolvers();
+  };
+
+  const subscription = observable.subscribe({
+    complete() {
+      push([COMPLETE]);
+    },
+    error(err: unknown) {
+      push([THROW, err]);
+    },
+    next(value: T) {
+      push([NEXT, value]);
+    }
+  });
+
+  const asyncIterableIterator: AsyncIterableIterator<T> = {
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    async next(): Promise<IteratorResult<T>> {
+      let entry = queue.shift();
+
+      if (!entry) {
+        entry = await deferred.promise;
+        queue.shift();
+      }
+
+      switch (entry[0]) {
+        case COMPLETE:
+          return { done: true, value: undefined };
+
+        case THROW:
+          throw entry[1];
+
+        case NEXT:
+          return { done: false, value: entry[1] };
+      }
+    },
+    async return() {
+      subscription.unsubscribe();
+
+      return { done: true, value: undefined };
+    },
+    async throw() {
+      subscription.unsubscribe();
+
+      return { done: true, value: undefined };
+    }
+  };
+
+  return asyncIterableIterator;
+}

--- a/packages/iter-fest/src/private/JestMockOf.ts
+++ b/packages/iter-fest/src/private/JestMockOf.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type JestMockOf<T extends (this: any, ...args: any[]) => any> = jest.Mock<
+  ReturnType<T>,
+  Parameters<T>,
+  ThisParameterType<T>
+>;

--- a/packages/iter-fest/src/private/withResolvers.ts
+++ b/packages/iter-fest/src/private/withResolvers.ts
@@ -1,0 +1,6 @@
+// @ts-expect-error "core-js" is not typed.
+import coreJSPromiseWithResolvers from 'core-js-pure/full/promise/with-resolvers';
+
+export default function withResolvers<T>(): PromiseWithResolvers<T> {
+  return coreJSPromiseWithResolvers();
+}

--- a/packages/iter-fest/tsup.config.ts
+++ b/packages/iter-fest/tsup.config.ts
@@ -25,7 +25,9 @@ export default defineConfig([
       'iter-fest.iterableSome': './src/iterableSome.ts',
       'iter-fest.iterableToSpliced': './src/iterableToSpliced.ts',
       'iter-fest.iterableToString': './src/iterableToString.ts',
-      'iter-fest.iteratorToIterable': './src/iteratorToIterable.ts'
+      'iter-fest.iteratorToIterable': './src/iteratorToIterable.ts',
+      'iter-fest.observable': './src/Observable.ts',
+      'iter-fest.symbolObservable': './src/SymbolObservable.ts'
     },
     format: ['cjs', 'esm'],
     sourcemap: true

--- a/packages/iter-fest/tsup.config.ts
+++ b/packages/iter-fest/tsup.config.ts
@@ -27,6 +27,7 @@ export default defineConfig([
       'iter-fest.iterableToString': './src/iterableToString.ts',
       'iter-fest.iteratorToIterable': './src/iteratorToIterable.ts',
       'iter-fest.observable': './src/Observable.ts',
+      'iter-fest.observableValues': './src/observableValues.ts',
       'iter-fest.symbolObservable': './src/SymbolObservable.ts'
     },
     format: ['cjs', 'esm'],


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Added typed `Observable` from `core-js-pure`, in PR [#8](https://github.com/compulim/iter-fest/pull/8)
- Added `observableValues` to convert `Observable` into `AsyncIterableIterator` in PR [#8](https://github.com/compulim/iter-fest/pull/8)

## Specific changes

> Please list each individual specific change in this pull request.

- Added `Observable`
- Added `observableValues`