### PR TITLE
Add `observableFromAsync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added typed `Observable` from `core-js-pure`, in PR [#8](https://github.com/compulim/iter-fest/pull/8)
 - Added `observableValues` to convert `Observable` into `AsyncIterableIterator` in PR [#8](https://github.com/compulim/iter-fest/pull/8)
+- Added `observableFromAsync` to convert `AsyncIterable` into `Observable` in PR [#9](https://github.com/compulim/iter-fest/pull/9)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ for (const value of iteratorToIterable(iterate())) {
 
 `Observable` and `Symbol.observable` is re-exported from `core-js-pure` with proper type definitions.
 
-### Converting an `Observable` to `AsyncIterable`
+### Converting an `Observable` to `AsyncIterableIterator`
 
 `observableValues` subscribes to an `Observable` and return as `AsyncIterableIterator`.
 
@@ -73,6 +73,25 @@ const observable = Observable.from([1, 2, 3]);
 for await (const value of observableValues(observable)) {
   console.log(value); // Prints "1", "2", "3".
 }
+```
+
+### Converting an `AsyncIterable` to `Observable`
+
+`Observable.from` converts `Iterable` into `Observable`. However, it does not convert `AsyncIterable`.
+
+`observableFromAsync` will convert `AsyncIterable` into `Observable`.
+
+```ts
+async function* generate() {
+  yield 1;
+  yield 2;
+  yield 3;
+}
+
+const observable = observableFromAsync(generate());
+const next = value => console.log(value);
+
+observable.subscribe({ next }); // Prints "1", "2", "3".
 ```
 
 ## Behaviors

--- a/packages/integration-test/importDefault.test.ts
+++ b/packages/integration-test/importDefault.test.ts
@@ -21,6 +21,7 @@ import {
   iterableToString,
   iteratorToIterable,
   Observable,
+  observableFromAsync,
   observableValues,
   SymbolObservable
 } from 'iter-fest';
@@ -108,6 +109,25 @@ test('Observable should work', () => {
   expect(next).toHaveBeenCalledTimes(1);
   expect(next).toHaveBeenNthCalledWith(1, 1);
   expect(complete).toHaveBeenCalledTimes(1);
+});
+
+test('observableFromAsync should work', async () => {
+  const observable = observableFromAsync(
+    (async function* () {
+      yield 1;
+      yield 2;
+      yield 3;
+    })()
+  );
+
+  const next = jest.fn();
+
+  await new Promise<void>(resolve => observable.subscribe({ complete: resolve, next }));
+
+  expect(next).toHaveBeenCalledTimes(3);
+  expect(next).toHaveBeenNthCalledWith(1, 1);
+  expect(next).toHaveBeenNthCalledWith(2, 2);
+  expect(next).toHaveBeenNthCalledWith(3, 3);
 });
 
 test('observableValues should work', async () => {

--- a/packages/integration-test/importNamed.test.ts
+++ b/packages/integration-test/importNamed.test.ts
@@ -20,6 +20,7 @@ import { iterableToSpliced } from 'iter-fest/iterableToSpliced';
 import { iterableToString } from 'iter-fest/iterableToString';
 import { iteratorToIterable } from 'iter-fest/iteratorToIterable';
 import { Observable } from 'iter-fest/observable';
+import { observableFromAsync } from 'iter-fest/observableFromAsync';
 import { observableValues } from 'iter-fest/observableValues';
 import { SymbolObservable } from 'iter-fest/symbolObservable';
 
@@ -106,6 +107,25 @@ test('Observable should work', () => {
   expect(next).toHaveBeenCalledTimes(1);
   expect(next).toHaveBeenNthCalledWith(1, 1);
   expect(complete).toHaveBeenCalledTimes(1);
+});
+
+test('observableFromAsync should work', async () => {
+  const observable = observableFromAsync(
+    (async function* () {
+      yield 1;
+      yield 2;
+      yield 3;
+    })()
+  );
+
+  const next = jest.fn();
+
+  await new Promise<void>(resolve => observable.subscribe({ complete: resolve, next }));
+
+  expect(next).toHaveBeenCalledTimes(3);
+  expect(next).toHaveBeenNthCalledWith(1, 1);
+  expect(next).toHaveBeenNthCalledWith(2, 2);
+  expect(next).toHaveBeenNthCalledWith(3, 3);
 });
 
 test('observableValues should work', async () => {

--- a/packages/integration-test/requireNamed.test.cjs
+++ b/packages/integration-test/requireNamed.test.cjs
@@ -20,6 +20,7 @@ const { iterableToSpliced } = require('iter-fest/iterableToSpliced');
 const { iterableToString } = require('iter-fest/iterableToString');
 const { iteratorToIterable } = require('iter-fest/iteratorToIterable');
 const { Observable } = require('iter-fest/observable');
+const { observableFromAsync } = require('iter-fest/observableFromAsync');
 const { observableValues } = require('iter-fest/observableValues');
 const { SymbolObservable } = require('iter-fest/symbolObservable');
 
@@ -106,6 +107,25 @@ test('Observable should work', () => {
   expect(next).toHaveBeenCalledTimes(1);
   expect(next).toHaveBeenNthCalledWith(1, 1);
   expect(complete).toHaveBeenCalledTimes(1);
+});
+
+test('observableFromAsync should work', async () => {
+  const observable = observableFromAsync(
+    (async function* () {
+      yield 1;
+      yield 2;
+      yield 3;
+    })()
+  );
+
+  const next = jest.fn();
+
+  await new Promise(resolve => observable.subscribe({ complete: resolve, next }));
+
+  expect(next).toHaveBeenCalledTimes(3);
+  expect(next).toHaveBeenNthCalledWith(1, 1);
+  expect(next).toHaveBeenNthCalledWith(2, 2);
+  expect(next).toHaveBeenNthCalledWith(3, 3);
 });
 
 test('observableValues should work', async () => {

--- a/packages/integration-test/requiredDefault.test.cjs
+++ b/packages/integration-test/requiredDefault.test.cjs
@@ -21,6 +21,7 @@ const {
   iterableToString,
   iteratorToIterable,
   Observable,
+  observableFromAsync,
   observableValues,
   SymbolObservable
 } = require('iter-fest');
@@ -108,6 +109,25 @@ test('Observable should work', () => {
   expect(next).toHaveBeenCalledTimes(1);
   expect(next).toHaveBeenNthCalledWith(1, 1);
   expect(complete).toHaveBeenCalledTimes(1);
+});
+
+test('observableFromAsync should work', async () => {
+  const observable = observableFromAsync(
+    (async function* () {
+      yield 1;
+      yield 2;
+      yield 3;
+    })()
+  );
+
+  const next = jest.fn();
+
+  await new Promise(resolve => observable.subscribe({ complete: resolve, next }));
+
+  expect(next).toHaveBeenCalledTimes(3);
+  expect(next).toHaveBeenNthCalledWith(1, 1);
+  expect(next).toHaveBeenNthCalledWith(2, 2);
+  expect(next).toHaveBeenNthCalledWith(3, 3);
 });
 
 test('observableValues should work', async () => {

--- a/packages/iter-fest/package.json
+++ b/packages/iter-fest/package.json
@@ -226,6 +226,16 @@
         "default": "./dist/iter-fest.observable.js"
       }
     },
+    "./observableFromAsync": {
+      "import": {
+        "types": "./dist/iter-fest.observableFromAsync.d.mts",
+        "default": "./dist/iter-fest.observableFromAsync.mjs"
+      },
+      "require": {
+        "types": "./dist/iter-fest.observableFromAsync.d.ts",
+        "default": "./dist/iter-fest.observableFromAsync.js"
+      }
+    },
     "./observableValues": {
       "import": {
         "types": "./dist/iter-fest.observableValues.d.mts",

--- a/packages/iter-fest/src/index.ts
+++ b/packages/iter-fest/src/index.ts
@@ -21,4 +21,5 @@ export * from './iterableSome';
 export * from './iterableToSpliced';
 export * from './iterableToString';
 export * from './iteratorToIterable';
+export * from './observableFromAsync';
 export * from './observableValues';

--- a/packages/iter-fest/src/observableFromAsync.spec.ts
+++ b/packages/iter-fest/src/observableFromAsync.spec.ts
@@ -1,0 +1,78 @@
+import type { CompleteFunction, ErrorFunction, NextFunction, Observable, StartFunction } from './Observable';
+import { observableFromAsync } from './observableFromAsync';
+
+import { type JestMockOf } from './private/JestMockOf';
+import withResolvers from './private/withResolvers';
+
+describe('comprehensive', () => {
+  let complete: JestMockOf<CompleteFunction>;
+  let error: JestMockOf<ErrorFunction>;
+  let iterable: AsyncIterableIterator<number>;
+  let iterableNextReject: (error: unknown) => void;
+  let iterableNextResolve: (result: IteratorResult<number>) => void;
+  let next: JestMockOf<NextFunction<number>>;
+  let observable: Observable<number>;
+  let start: JestMockOf<StartFunction>;
+  let iterableNextDeferred: PromiseWithResolvers<IteratorResult<number>>;
+
+  beforeEach(() => {
+    iterableNextDeferred = withResolvers();
+
+    iterableNextReject = jest.fn().mockImplementation(error => {
+      iterableNextDeferred.reject(error);
+      iterableNextDeferred = withResolvers();
+    });
+
+    iterableNextResolve = jest.fn().mockImplementation(value => {
+      iterableNextDeferred.resolve(value);
+      iterableNextDeferred = withResolvers();
+    });
+
+    iterable = {
+      [Symbol.asyncIterator]() {
+        return iterable;
+      },
+      next() {
+        return iterableNextDeferred.promise;
+      }
+    };
+
+    complete = jest.fn();
+    error = jest.fn();
+    next = jest.fn();
+    start = jest.fn();
+
+    observable = observableFromAsync(iterable);
+
+    observable.subscribe({ complete, error, next, start });
+  });
+
+  test('start() should have been called once', () => expect(start).toHaveBeenCalledTimes(1));
+
+  describe('when iterable.next() is called with a value', () => {
+    beforeEach(() => iterableNextResolve({ value: 1 }));
+
+    describe('observable.next() should have been called', () => {
+      test('once', () => expect(next).toHaveBeenCalledTimes(1));
+      test('with value', () => expect(next).toHaveBeenNthCalledWith(1, 1));
+    });
+  });
+
+  describe('when iterable.next() is called with completion', () => {
+    beforeEach(() => iterableNextResolve({ done: true, value: undefined }));
+
+    test('observable.complete() should have been called once', () => expect(complete).toHaveBeenCalledTimes(1));
+  });
+
+  describe('when iterable.next() is called with exception', () => {
+    beforeEach(() => iterableNextReject(new Error('artificial')));
+
+    describe('observable.error() should have been called', () => {
+      test('once', () => expect(error).toHaveBeenCalledTimes(1));
+      test('with the error', () =>
+        expect(() => {
+          throw error.mock.calls[0]?.[0];
+        }).toThrow('artificial'));
+    });
+  });
+});

--- a/packages/iter-fest/src/observableFromAsync.ts
+++ b/packages/iter-fest/src/observableFromAsync.ts
@@ -1,0 +1,27 @@
+import { Observable } from './Observable';
+
+export function observableFromAsync<T>(iterable: AsyncIterable<T>): Observable<T> {
+  return new Observable(subscriber => {
+    let closed = false;
+
+    (async function () {
+      try {
+        for await (const value of iterable) {
+          if (closed) {
+            break;
+          }
+
+          subscriber.next(value);
+        }
+
+        subscriber.complete();
+      } catch (error) {
+        subscriber.error(error);
+      }
+    })();
+
+    return () => {
+      closed = true;
+    };
+  });
+}

--- a/packages/iter-fest/tsup.config.ts
+++ b/packages/iter-fest/tsup.config.ts
@@ -27,6 +27,7 @@ export default defineConfig([
       'iter-fest.iterableToString': './src/iterableToString.ts',
       'iter-fest.iteratorToIterable': './src/iteratorToIterable.ts',
       'iter-fest.observable': './src/Observable.ts',
+      'iter-fest.observableFromAsync': './src/observableFromAsync.ts',
       'iter-fest.observableValues': './src/observableValues.ts',
       'iter-fest.symbolObservable': './src/SymbolObservable.ts'
     },


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Added `observableFromAsync` to convert `AsyncIterable` into `Observable` in PR [#9](https://github.com/compulim/iter-fest/pull/9)

## Specific changes

> Please list each individual specific change in this pull request.

- Added `observableFromAsync`