### PR TITLE
Add `asyncIteratorToAsyncIterable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `observableSubscribeAsReadable` in PR [#13](https://github.com/compulim/iter-fest/pull/13)
 - Added `iterableGetReadable` in PR [#15](https://github.com/compulim/iter-fest/pull/15)
 - Added `generatorWithLastValue`/`asyncGeneratorWithLastValue` in PR [#17](https://github.com/compulim/iter-fest/pull/17)
+- Added `asyncIteratorToAsyncIterable` in PR [#18](https://github.com/compulim/iter-fest/pull/18)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To convert `Observable` to `AsyncIterableIterator`, [use `ReadableStream` as int
 
 ### Converting an iterator to iterable
 
-`iteratorToIterable` and `asyncIterableToAsyncIterable` enable a [pure iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) to be iterable using a for-loop statement.
+`iteratorToIterable` and `asyncIteratorToAsyncIterable` enable a [pure iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) to be iterable using a for-loop statement.
 
 ```ts
 const iterate = (): Iterator<number> => {

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ List of ported functions: [`at`](https://tc39.es/ecma262/#sec-array.prototype.at
 | From                          | To                      | Function signature                                                                                                                               |
 | ----------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `Iterator`                    | `IterableIterator`      | [`iteratorToIterable<T>(iterator: Iterator<T>): IterableIterator<T>`](#converting-an-iterator-to-iterable)                                       |
+| `AsyncIterator`               | `AsyncIterableIterator` | [`asyncIteratorToAsyncIterable<T>(asyncIterator: AsyncIterator<T>): AsyncIterableIterator<T>`](#converting-an-iterator-to-iterable)              |
 | `Observable`                  | `ReadableStream`        | [`observableSubscribeAsReadable<T>(observable: Observable<T>): ReadableStream<T>`](#converting-an-observable-to-readablestream)                  |
 | `ReadableStreamDefaultReader` | `AsyncIterableIterator` | [`readerValues`<T>(reader: ReadableStreamDefaultReader<T>): AsyncIterableIterator<T>`](#iterating-readablestreamdefaultreader)                   |
 | `AsyncIterable`               | `Observable`            | [`observableFromAsync<T>(iterable: AsyncIterable<T>): Observable<T>`](#converting-an-asynciterable-to-observable)                                |
@@ -47,7 +48,7 @@ To convert `Observable` to `AsyncIterableIterator`, [use `ReadableStream` as int
 
 ### Converting an iterator to iterable
 
-`iteratorToIterable` enable a [pure iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) to be iterable using a for-loop statement.
+`iteratorToIterable` and `asyncIterableToAsyncIterable` enable a [pure iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) to be iterable using a for-loop statement.
 
 ```ts
 const iterate = (): Iterator<number> => {

--- a/packages/integration-test/importDefault.test.ts
+++ b/packages/integration-test/importDefault.test.ts
@@ -4,6 +4,7 @@ import {
   PushAsyncIterableIterator,
   SymbolObservable,
   asyncGeneratorWithLastValue,
+  asyncIteratorToAsyncIterable,
   generatorWithLastValue,
   iterableAt,
   iterableConcat,
@@ -31,6 +32,26 @@ import {
   observableSubscribeAsReadable,
   readerValues
 } from 'iter-fest';
+
+test('asyncIteratorToIterable should work', async () => {
+  const iterable = asyncIteratorToAsyncIterable(
+    ((): AsyncIterator<number> => {
+      let value = 0;
+
+      return {
+        next: () => Promise.resolve(++value <= 3 ? { done: false, value } : { done: true, value: undefined })
+      };
+    })()
+  );
+
+  const values: number[] = [];
+
+  for await (const value of iterable) {
+    values.push(value);
+  }
+
+  expect(values).toEqual([1, 2, 3]);
+});
 
 test('asyncGeneratorWithLastValue should work', async () => {
   const asyncGenerator = asyncGeneratorWithLastValue(

--- a/packages/integration-test/importNamed.test.ts
+++ b/packages/integration-test/importNamed.test.ts
@@ -1,5 +1,6 @@
 import withResolvers from 'core-js-pure/full/promise/with-resolvers';
 import { asyncGeneratorWithLastValue } from 'iter-fest/asyncGeneratorWithLastValue';
+import { asyncIteratorToAsyncIterable } from 'iter-fest/asyncIteratorToAsyncIterable';
 import { generatorWithLastValue } from 'iter-fest/generatorWithLastValue';
 import { iterableAt } from 'iter-fest/iterableAt';
 import { iterableConcat } from 'iter-fest/iterableConcat';
@@ -44,6 +45,26 @@ test('asyncGeneratorWithLastValue should work', async () => {
   }
 
   expect(asyncGenerator.lastValue()).toEqual('end');
+});
+
+test('asyncIteratorToIterable should work', async () => {
+  const iterable = asyncIteratorToAsyncIterable(
+    ((): AsyncIterator<number> => {
+      let value = 0;
+
+      return {
+        next: () => Promise.resolve(++value <= 3 ? { done: false, value } : { done: true, value: undefined })
+      };
+    })()
+  );
+
+  const values: number[] = [];
+
+  for await (const value of iterable) {
+    values.push(value);
+  }
+
+  expect(values).toEqual([1, 2, 3]);
 });
 
 test('generatorWithLastValue should work', () => {

--- a/packages/integration-test/requireNamed.test.cjs
+++ b/packages/integration-test/requireNamed.test.cjs
@@ -1,6 +1,7 @@
 const withResolvers = require('core-js-pure/full/promise/with-resolvers');
 
 const { asyncGeneratorWithLastValue } = require('iter-fest/asyncGeneratorWithLastValue');
+const { asyncIteratorToAsyncIterable } = require('iter-fest/asyncIteratorToAsyncIterable');
 const { generatorWithLastValue } = require('iter-fest/generatorWithLastValue');
 const { iterableAt } = require('iter-fest/iterableAt');
 const { iterableConcat } = require('iter-fest/iterableConcat');
@@ -45,6 +46,26 @@ test('asyncGeneratorWithLastValue should work', async () => {
   }
 
   expect(asyncGenerator.lastValue()).toEqual('end');
+});
+
+test('asyncIteratorToIterable should work', async () => {
+  const iterable = asyncIteratorToAsyncIterable(
+    (() => {
+      let value = 0;
+
+      return {
+        next: () => Promise.resolve(++value <= 3 ? { done: false, value } : { done: true, value: undefined })
+      };
+    })()
+  );
+
+  const values = [];
+
+  for await (const value of iterable) {
+    values.push(value);
+  }
+
+  expect(values).toEqual([1, 2, 3]);
 });
 
 test('generatorWithLastValue should work', () => {

--- a/packages/integration-test/requiredDefault.test.cjs
+++ b/packages/integration-test/requiredDefault.test.cjs
@@ -2,6 +2,7 @@ const withResolvers = require('core-js-pure/full/promise/with-resolvers');
 
 const {
   asyncGeneratorWithLastValue,
+  asyncIteratorToAsyncIterable,
   generatorWithLastValue,
   iterableAt,
   iterableConcat,
@@ -47,6 +48,26 @@ test('asyncGeneratorWithLastValue should work', async () => {
   }
 
   expect(asyncGenerator.lastValue()).toEqual('end');
+});
+
+test('asyncIteratorToIterable should work', async () => {
+  const iterable = asyncIteratorToAsyncIterable(
+    (() => {
+      let value = 0;
+
+      return {
+        next: () => Promise.resolve(++value <= 3 ? { done: false, value } : { done: true, value: undefined })
+      };
+    })()
+  );
+
+  const values = [];
+
+  for await (const value of iterable) {
+    values.push(value);
+  }
+
+  expect(values).toEqual([1, 2, 3]);
 });
 
 test('generatorWithLastValue should work', () => {

--- a/packages/iter-fest/package.json
+++ b/packages/iter-fest/package.json
@@ -16,6 +16,16 @@
         "default": "./dist/iter-fest.asyncGeneratorWithLastValue.js"
       }
     },
+    "./asyncIteratorToAsyncIterable": {
+      "import": {
+        "types": "./dist/iter-fest.asyncIteratorToAsyncIterable.d.mts",
+        "default": "./dist/iter-fest.asyncIteratorToAsyncIterable.mjs"
+      },
+      "require": {
+        "types": "./dist/iter-fest.asyncIteratorToAsyncIterable.d.ts",
+        "default": "./dist/iter-fest.asyncIteratorToAsyncIterable.js"
+      }
+    },
     "./generatorWithLastValue": {
       "import": {
         "types": "./dist/iter-fest.generatorWithLastValue.d.mts",

--- a/packages/iter-fest/src/asyncIteratorToAsyncIterable.spec.ts
+++ b/packages/iter-fest/src/asyncIteratorToAsyncIterable.spec.ts
@@ -1,0 +1,28 @@
+import { asyncIteratorToAsyncIterable } from './asyncIteratorToAsyncIterable';
+
+describe('passing an async iterator-compatible generator', () => {
+  let asyncIterable: AsyncIterableIterator<number>;
+
+  beforeEach(() => {
+    const iterate = (): AsyncIterator<number> => {
+      let value = 0;
+
+      return {
+        next: (): Promise<IteratorResult<number>> =>
+          Promise.resolve(++value <= 3 ? { done: false, value } : { done: true, value: undefined })
+      };
+    };
+
+    asyncIterable = asyncIteratorToAsyncIterable(iterate());
+  });
+
+  test('should be iterable', async () => {
+    const values: number[] = [];
+
+    for await (const value of asyncIterable) {
+      values.push(value);
+    }
+
+    expect(values).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/iter-fest/src/asyncIteratorToAsyncIterable.ts
+++ b/packages/iter-fest/src/asyncIteratorToAsyncIterable.ts
@@ -1,0 +1,10 @@
+export function asyncIteratorToAsyncIterable<T>(asyncIterator: AsyncIterator<T>): AsyncIterableIterator<T> {
+  const asyncIterableIterator: AsyncIterableIterator<T> = {
+    [Symbol.asyncIterator]: () => asyncIterableIterator,
+    next: asyncIterator.next.bind(asyncIterator),
+    ...(asyncIterator.return ? { return: asyncIterator.return.bind(asyncIterator) } : {}),
+    ...(asyncIterator.throw ? { throw: asyncIterator.throw.bind(asyncIterator) } : {})
+  };
+
+  return asyncIterableIterator;
+}

--- a/packages/iter-fest/src/index.ts
+++ b/packages/iter-fest/src/index.ts
@@ -2,6 +2,7 @@ export * from './Observable';
 export * from './PushAsyncIterableIterator';
 export * from './SymbolObservable';
 export * from './asyncGeneratorWithLastValue';
+export * from './asyncIteratorToAsyncIterable';
 export * from './generatorWithLastValue';
 export * from './iterableAt';
 export * from './iterableConcat';

--- a/packages/iter-fest/tsup.config.ts
+++ b/packages/iter-fest/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig([
     entry: {
       'iter-fest': './src/index.ts',
       'iter-fest.asyncGeneratorWithLastValue': './src/asyncGeneratorWithLastValue.ts',
+      'iter-fest.asyncIteratorToAsyncIterable': './src/asyncIteratorToAsyncIterable.ts',
       'iter-fest.generatorWithLastValue': './src/generatorWithLastValue.ts',
       'iter-fest.iterableAt': './src/iterableAt.ts',
       'iter-fest.iterableConcat': './src/iterableConcat.ts',


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Added `asyncIteratorToAsyncIterable` in PR [#18](https://github.com/compulim/iter-fest/pull/18)

## Specific changes

> Please list each individual specific change in this pull request.

- Added `asyncIteratorToAsyncIterable`
- Updated `README.md`