### PR TITLE
Add TC39 sample to tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `readableStreamFrom` in PR [#15](https://github.com/compulim/iter-fest/pull/15) and [#22](https://github.com/compulim/iter-fest/pull/22)
 - Added `generatorWithLastValue`/`asyncGeneratorWithLastValue` in PR [#17](https://github.com/compulim/iter-fest/pull/17)
 - Added `asyncIteratorToAsyncIterable` in PR [#18](https://github.com/compulim/iter-fest/pull/18)
-- Added `iteratorDrop`, `iteratorFlatMap`, `iteratorFrom`, `iteratorTake`, `iteratorToArray` in PR [#24](https://github.com/compulim/iter-fest/pull/24)
+- Added `iteratorDrop`, `iteratorFlatMap`, `iteratorFrom`, `iteratorTake`, `iteratorToArray` in PR [#24](https://github.com/compulim/iter-fest/pull/24) and [#25](https://github.com/compulim/iter-fest/pull/25)
 
 ### Changed
 
-- Following functions will be using ponyfill from `core-js-pure` with types, in PR [#24](https://github.com/compulim/iter-fest/pull/24)
+- Following functions will be using ponyfill from `core-js-pure` with types, in PR [#24](https://github.com/compulim/iter-fest/pull/24) and [#25](https://github.com/compulim/iter-fest/pull/25)
    - `iteratorEvery`, `iteratorFilter`, `iteratorFind`, `iteratorForEach`, `iteratorMap`, `iteratorReduce`, `iteratorSome`
 - Bumped dependencies, in PR [#7](https://github.com/compulim/iter-fest/pull/7)
    - Development dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+
+- `iterable*` is now `iterator*` to align closer to TC39 iterator helper proposal
+
 ### Added
 
 - Added typed `Observable` from `core-js-pure`, in PR [#8](https://github.com/compulim/iter-fest/pull/8)

--- a/packages/integration-test/importDefault/iteratorEvery.test.ts
+++ b/packages/integration-test/importDefault/iteratorEvery.test.ts
@@ -1,3 +1,20 @@
-import { iteratorEvery } from 'iter-fest';
+import { iteratorEvery, iteratorTake } from 'iter-fest';
 
-test('iteratorEvery should work', () => expect(iteratorEvery([1, 2, 3].values(), value => value)).toBe(true));
+test('iteratorEvery should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+    while (true) {
+      yield i;
+      i += 1;
+    }
+  }
+
+  const iter = iteratorTake(naturals(), 10);
+
+  expect(iteratorEvery(iter, v => v >= 0)).toBe(true);
+  expect(iteratorEvery(iter, () => false)).toBe(true); // iterator is already consumed.
+
+  expect(iteratorEvery(iteratorTake(naturals(), 4), v => v > 0)).toEqual(false); // first value is 0
+  expect(iteratorEvery(iteratorTake(naturals(), 4), v => v >= 0)).toEqual(true); // acting on a new iterator
+});

--- a/packages/integration-test/importDefault/iteratorFilter.test.ts
+++ b/packages/integration-test/importDefault/iteratorFilter.test.ts
@@ -1,4 +1,22 @@
 import { iteratorFilter } from 'iter-fest';
 
-test('iteratorFilter should work', () =>
-  expect(Array.from(iteratorFilter([1, 2, 3].values(), value => value % 2))).toEqual([1, 3]));
+test('iteratorFilter should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorFilter(naturals(), value => {
+    return value % 2 == 0;
+  });
+
+  expect(result.next()).toEqual({ done: false, value: 0 });
+  expect(result.next()).toEqual({ done: false, value: 2 });
+  expect(result.next()).toEqual({ done: false, value: 4 });
+});

--- a/packages/integration-test/importDefault/iteratorFind.test.ts
+++ b/packages/integration-test/importDefault/iteratorFind.test.ts
@@ -1,3 +1,16 @@
 import { iteratorFind } from 'iter-fest';
 
-test('iteratorFind should work', () => expect(iteratorFind([1, 2, 3].values(), value => value % 2)).toBe(1));
+test('iteratorFind should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  expect(iteratorFind(naturals(), v => v > 1)).toBe(2);
+});

--- a/packages/integration-test/importDefault/iteratorForEach.test.ts
+++ b/packages/integration-test/importDefault/iteratorForEach.test.ts
@@ -1,9 +1,12 @@
 import { iteratorForEach } from 'iter-fest';
 
 test('iteratorForEach should work', () => {
-  const callbackfn = jest.fn();
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  const log: number[] = [];
+  const fn = (value: number) => log.push(value);
+  const iter = [1, 2, 3].values();
 
-  iteratorForEach([1, 2, 3].values(), callbackfn);
+  iteratorForEach(iter, fn);
 
-  expect(callbackfn).toHaveBeenCalledTimes(3);
+  expect(log.join(', ')).toBe('1, 2, 3');
 });

--- a/packages/integration-test/importDefault/iteratorMap.test.ts
+++ b/packages/integration-test/importDefault/iteratorMap.test.ts
@@ -1,8 +1,22 @@
 import { iteratorMap } from 'iter-fest';
 
-test('iteratorMap should work', () =>
-  expect(Array.from(iteratorMap([1, 2, 3].values(), value => String.fromCharCode(value + 64)))).toEqual([
-    'A',
-    'B',
-    'C'
-  ]));
+test('iteratorMap should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorMap(naturals(), value => {
+    return value * value;
+  });
+
+  expect(result.next()).toEqual({ done: false, value: 0 });
+  expect(result.next()).toEqual({ done: false, value: 1 });
+  expect(result.next()).toEqual({ done: false, value: 4 });
+});

--- a/packages/integration-test/importDefault/iteratorReduce.test.ts
+++ b/packages/integration-test/importDefault/iteratorReduce.test.ts
@@ -1,4 +1,24 @@
-import { iteratorReduce } from 'iter-fest';
+import { iteratorReduce, iteratorTake } from 'iter-fest';
 
-test('iteratorReduce should work', () =>
-  expect(iteratorReduce([1, 2, 3].values(), (previousValue, currentValue) => previousValue + currentValue, 0)).toBe(6));
+test('iteratorReduce should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorReduce(
+    iteratorTake(naturals(), 5),
+    (sum, value) => {
+      return sum + value;
+    },
+    3
+  );
+
+  expect(result).toBe(13);
+});

--- a/packages/integration-test/importDefault/iteratorSome.test.ts
+++ b/packages/integration-test/importDefault/iteratorSome.test.ts
@@ -1,3 +1,22 @@
-import { iteratorSome } from 'iter-fest';
+import { iteratorSome, iteratorTake } from 'iter-fest';
 
-test('iteratorSome should work', () => expect(iteratorSome([1, 2, 3].values(), value => value % 2)).toBe(true));
+test('iteratorSome should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const iter = iteratorTake(naturals(), 4);
+
+  expect(iteratorSome(iter, v => v > 1)).toEqual(true);
+  expect(iteratorSome(iter, () => true)).toEqual(false); // iterator is already consumed.
+
+  expect(iteratorSome(iteratorTake(naturals(), 4), v => v > 1)).toEqual(true);
+  expect(iteratorSome(iteratorTake(naturals(), 4), v => v == 1)).toEqual(true); // acting on a new iterator
+});

--- a/packages/integration-test/importNamed/iteratorEvery.test.ts
+++ b/packages/integration-test/importNamed/iteratorEvery.test.ts
@@ -1,3 +1,21 @@
 import { iteratorEvery } from 'iter-fest/iteratorEvery';
+import { iteratorTake } from 'iter-fest/iteratorTake';
 
-test('iteratorEvery should work', () => expect(iteratorEvery([1, 2, 3].values(), value => value)).toBe(true));
+test('iteratorEvery should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+    while (true) {
+      yield i;
+      i += 1;
+    }
+  }
+
+  const iter = iteratorTake(naturals(), 10);
+
+  expect(iteratorEvery(iter, v => v >= 0)).toBe(true);
+  expect(iteratorEvery(iter, () => false)).toBe(true); // iterator is already consumed.
+
+  expect(iteratorEvery(iteratorTake(naturals(), 4), v => v > 0)).toEqual(false); // first value is 0
+  expect(iteratorEvery(iteratorTake(naturals(), 4), v => v >= 0)).toEqual(true); // acting on a new iterator
+});

--- a/packages/integration-test/importNamed/iteratorFilter.test.ts
+++ b/packages/integration-test/importNamed/iteratorFilter.test.ts
@@ -1,4 +1,22 @@
 import { iteratorFilter } from 'iter-fest/iteratorFilter';
 
-test('iteratorFilter should work', () =>
-  expect(Array.from(iteratorFilter([1, 2, 3].values(), value => value % 2))).toEqual([1, 3]));
+test('iteratorFilter should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorFilter(naturals(), value => {
+    return value % 2 == 0;
+  });
+
+  expect(result.next()).toEqual({ done: false, value: 0 });
+  expect(result.next()).toEqual({ done: false, value: 2 });
+  expect(result.next()).toEqual({ done: false, value: 4 });
+});

--- a/packages/integration-test/importNamed/iteratorFind.test.ts
+++ b/packages/integration-test/importNamed/iteratorFind.test.ts
@@ -1,3 +1,16 @@
 import { iteratorFind } from 'iter-fest/iteratorFind';
 
-test('iteratorFind should work', () => expect(iteratorFind([1, 2, 3].values(), value => value % 2)).toBe(1));
+test('iteratorFind should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  expect(iteratorFind(naturals(), v => v > 1)).toBe(2);
+});

--- a/packages/integration-test/importNamed/iteratorForEach.test.ts
+++ b/packages/integration-test/importNamed/iteratorForEach.test.ts
@@ -1,9 +1,12 @@
 import { iteratorForEach } from 'iter-fest/iteratorForEach';
 
 test('iteratorForEach should work', () => {
-  const callbackfn = jest.fn();
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  const log: number[] = [];
+  const fn = (value: number) => log.push(value);
+  const iter = [1, 2, 3].values();
 
-  iteratorForEach([1, 2, 3].values(), callbackfn);
+  iteratorForEach(iter, fn);
 
-  expect(callbackfn).toHaveBeenCalledTimes(3);
+  expect(log.join(', ')).toBe('1, 2, 3');
 });

--- a/packages/integration-test/importNamed/iteratorMap.test.ts
+++ b/packages/integration-test/importNamed/iteratorMap.test.ts
@@ -1,8 +1,22 @@
 import { iteratorMap } from 'iter-fest/iteratorMap';
 
-test('iteratorMap should work', () =>
-  expect(Array.from(iteratorMap([1, 2, 3].values(), value => String.fromCharCode(value + 64)))).toEqual([
-    'A',
-    'B',
-    'C'
-  ]));
+test('iteratorMap should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorMap(naturals(), value => {
+    return value * value;
+  });
+
+  expect(result.next()).toEqual({ done: false, value: 0 });
+  expect(result.next()).toEqual({ done: false, value: 1 });
+  expect(result.next()).toEqual({ done: false, value: 4 });
+});

--- a/packages/integration-test/importNamed/iteratorReduce.test.ts
+++ b/packages/integration-test/importNamed/iteratorReduce.test.ts
@@ -1,4 +1,25 @@
 import { iteratorReduce } from 'iter-fest/iteratorReduce';
+import { iteratorTake } from 'iter-fest/iteratorTake';
 
-test('iteratorReduce should work', () =>
-  expect(iteratorReduce([1, 2, 3].values(), (previousValue, currentValue) => previousValue + currentValue, 0)).toBe(6));
+test('iteratorReduce should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorReduce(
+    iteratorTake(naturals(), 5),
+    (sum, value) => {
+      return sum + value;
+    },
+    3
+  );
+
+  expect(result).toBe(13);
+});

--- a/packages/integration-test/importNamed/iteratorSome.test.ts
+++ b/packages/integration-test/importNamed/iteratorSome.test.ts
@@ -1,3 +1,23 @@
 import { iteratorSome } from 'iter-fest/iteratorSome';
+import { iteratorTake } from 'iter-fest/iteratorTake';
 
-test('iteratorSome should work', () => expect(iteratorSome([1, 2, 3].values(), value => value % 2)).toBe(true));
+test('iteratorSome should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const iter = iteratorTake(naturals(), 4);
+
+  expect(iteratorSome(iter, v => v > 1)).toEqual(true);
+  expect(iteratorSome(iter, () => true)).toEqual(false); // iterator is already consumed.
+
+  expect(iteratorSome(iteratorTake(naturals(), 4), v => v > 1)).toEqual(true);
+  expect(iteratorSome(iteratorTake(naturals(), 4), v => v == 1)).toEqual(true); // acting on a new iterator
+});

--- a/packages/integration-test/requireDefault/iteratorEvery.test.ts
+++ b/packages/integration-test/requireDefault/iteratorEvery.test.ts
@@ -1,4 +1,21 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { iteratorEvery } = require('iter-fest');
+const { iteratorEvery, iteratorTake } = require('iter-fest');
 
-test('iteratorEvery should work', () => expect(iteratorEvery([1, 2, 3].values(), value => value)).toBe(true));
+test('iteratorEvery should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+    while (true) {
+      yield i;
+      i += 1;
+    }
+  }
+
+  const iter = iteratorTake(naturals(), 10);
+
+  expect(iteratorEvery(iter, v => v >= 0)).toBe(true);
+  expect(iteratorEvery(iter, () => false)).toBe(true); // iterator is already consumed.
+
+  expect(iteratorEvery(iteratorTake(naturals(), 4), v => v > 0)).toEqual(false); // first value is 0
+  expect(iteratorEvery(iteratorTake(naturals(), 4), v => v >= 0)).toEqual(true); // acting on a new iterator
+});

--- a/packages/integration-test/requireDefault/iteratorFilter.test.ts
+++ b/packages/integration-test/requireDefault/iteratorFilter.test.ts
@@ -1,5 +1,23 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { iteratorFilter } = require('iter-fest');
 
-test('iteratorFilter should work', () =>
-  expect(Array.from(iteratorFilter([1, 2, 3].values(), value => value % 2))).toEqual([1, 3]));
+test('iteratorFilter should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorFilter(naturals(), value => {
+    return value % 2 == 0;
+  });
+
+  expect(result.next()).toEqual({ done: false, value: 0 });
+  expect(result.next()).toEqual({ done: false, value: 2 });
+  expect(result.next()).toEqual({ done: false, value: 4 });
+});

--- a/packages/integration-test/requireDefault/iteratorFind.test.ts
+++ b/packages/integration-test/requireDefault/iteratorFind.test.ts
@@ -1,4 +1,17 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { iteratorFind } = require('iter-fest');
 
-test('iteratorFind should work', () => expect(iteratorFind([1, 2, 3].values(), value => value % 2)).toBe(1));
+test('iteratorFind should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  expect(iteratorFind(naturals(), v => v > 1)).toBe(2);
+});

--- a/packages/integration-test/requireDefault/iteratorForEach.test.ts
+++ b/packages/integration-test/requireDefault/iteratorForEach.test.ts
@@ -2,9 +2,12 @@
 const { iteratorForEach } = require('iter-fest');
 
 test('iteratorForEach should work', () => {
-  const callbackfn = jest.fn();
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  const log: number[] = [];
+  const fn = (value: number) => log.push(value);
+  const iter = [1, 2, 3].values();
 
-  iteratorForEach([1, 2, 3].values(), callbackfn);
+  iteratorForEach(iter, fn);
 
-  expect(callbackfn).toHaveBeenCalledTimes(3);
+  expect(log.join(', ')).toBe('1, 2, 3');
 });

--- a/packages/integration-test/requireDefault/iteratorMap.test.ts
+++ b/packages/integration-test/requireDefault/iteratorMap.test.ts
@@ -1,9 +1,23 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { iteratorMap } = require('iter-fest');
 
-test('iteratorMap should work', () =>
-  expect(Array.from(iteratorMap([1, 2, 3].values(), value => String.fromCharCode(value + 64)))).toEqual([
-    'A',
-    'B',
-    'C'
-  ]));
+test('iteratorMap should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorMap(naturals(), value => {
+    return value * value;
+  });
+
+  expect(result.next()).toEqual({ done: false, value: 0 });
+  expect(result.next()).toEqual({ done: false, value: 1 });
+  expect(result.next()).toEqual({ done: false, value: 4 });
+});

--- a/packages/integration-test/requireDefault/iteratorReduce.test.ts
+++ b/packages/integration-test/requireDefault/iteratorReduce.test.ts
@@ -1,5 +1,25 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { iteratorReduce } = require('iter-fest');
+const { iteratorReduce, iteratorTake } = require('iter-fest');
 
-test('iteratorReduce should work', () =>
-  expect(iteratorReduce([1, 2, 3].values(), (previousValue, currentValue) => previousValue + currentValue, 0)).toBe(6));
+test('iteratorReduce should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorReduce(
+    iteratorTake(naturals(), 5),
+    (sum, value) => {
+      return sum + value;
+    },
+    3
+  );
+
+  expect(result).toBe(13);
+});

--- a/packages/integration-test/requireDefault/iteratorSome.test.ts
+++ b/packages/integration-test/requireDefault/iteratorSome.test.ts
@@ -1,4 +1,24 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { iteratorSome } = require('iter-fest');
+const { iteratorTake } = require('iter-fest');
 
-test('iteratorSome should work', () => expect(iteratorSome([1, 2, 3].values(), value => value % 2)).toBe(true));
+test('iteratorSome should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const iter = iteratorTake(naturals(), 4);
+
+  expect(iteratorSome(iter, v => v > 1)).toEqual(true);
+  expect(iteratorSome(iter, () => true)).toEqual(false); // iterator is already consumed.
+
+  expect(iteratorSome(iteratorTake(naturals(), 4), v => v > 1)).toEqual(true);
+  expect(iteratorSome(iteratorTake(naturals(), 4), v => v == 1)).toEqual(true); // acting on a new iterator
+});

--- a/packages/integration-test/requireNamed/iteratorEvery.test.ts
+++ b/packages/integration-test/requireNamed/iteratorEvery.test.ts
@@ -1,4 +1,22 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { iteratorEvery } = require('iter-fest/iteratorEvery');
+const { iteratorTake } = require('iter-fest/iteratorTake');
 
-test('iteratorEvery should work', () => expect(iteratorEvery([1, 2, 3].values(), value => value)).toBe(true));
+test('iteratorEvery should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+    while (true) {
+      yield i;
+      i += 1;
+    }
+  }
+
+  const iter = iteratorTake(naturals(), 10);
+
+  expect(iteratorEvery(iter, v => v >= 0)).toBe(true);
+  expect(iteratorEvery(iter, () => false)).toBe(true); // iterator is already consumed.
+
+  expect(iteratorEvery(iteratorTake(naturals(), 4), v => v > 0)).toEqual(false); // first value is 0
+  expect(iteratorEvery(iteratorTake(naturals(), 4), v => v >= 0)).toEqual(true); // acting on a new iterator
+});

--- a/packages/integration-test/requireNamed/iteratorFilter.test.ts
+++ b/packages/integration-test/requireNamed/iteratorFilter.test.ts
@@ -1,5 +1,23 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { iteratorFilter } = require('iter-fest/iteratorFilter');
 
-test('iteratorFilter should work', () =>
-  expect(Array.from(iteratorFilter([1, 2, 3].values(), value => value % 2))).toEqual([1, 3]));
+test('iteratorFilter should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorFilter(naturals(), value => {
+    return value % 2 == 0;
+  });
+
+  expect(result.next()).toEqual({ done: false, value: 0 });
+  expect(result.next()).toEqual({ done: false, value: 2 });
+  expect(result.next()).toEqual({ done: false, value: 4 });
+});

--- a/packages/integration-test/requireNamed/iteratorFind.test.ts
+++ b/packages/integration-test/requireNamed/iteratorFind.test.ts
@@ -1,4 +1,17 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { iteratorFind } = require('iter-fest/iteratorFind');
 
-test('iteratorFind should work', () => expect(iteratorFind([1, 2, 3].values(), value => value % 2)).toBe(1));
+test('iteratorFind should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  expect(iteratorFind(naturals(), v => v > 1)).toBe(2);
+});

--- a/packages/integration-test/requireNamed/iteratorForEach.test.ts
+++ b/packages/integration-test/requireNamed/iteratorForEach.test.ts
@@ -2,9 +2,12 @@
 const { iteratorForEach } = require('iter-fest/iteratorForEach');
 
 test('iteratorForEach should work', () => {
-  const callbackfn = jest.fn();
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  const log: number[] = [];
+  const fn = (value: number) => log.push(value);
+  const iter = [1, 2, 3].values();
 
-  iteratorForEach([1, 2, 3].values(), callbackfn);
+  iteratorForEach(iter, fn);
 
-  expect(callbackfn).toHaveBeenCalledTimes(3);
+  expect(log.join(', ')).toBe('1, 2, 3');
 });

--- a/packages/integration-test/requireNamed/iteratorMap.test.ts
+++ b/packages/integration-test/requireNamed/iteratorMap.test.ts
@@ -1,9 +1,23 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { iteratorMap } = require('iter-fest/iteratorMap');
 
-test('iteratorMap should work', () =>
-  expect(Array.from(iteratorMap([1, 2, 3].values(), value => String.fromCharCode(value + 64)))).toEqual([
-    'A',
-    'B',
-    'C'
-  ]));
+test('iteratorMap should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorMap(naturals(), value => {
+    return value * value;
+  });
+
+  expect(result.next()).toEqual({ done: false, value: 0 });
+  expect(result.next()).toEqual({ done: false, value: 1 });
+  expect(result.next()).toEqual({ done: false, value: 4 });
+});

--- a/packages/integration-test/requireNamed/iteratorReduce.test.ts
+++ b/packages/integration-test/requireNamed/iteratorReduce.test.ts
@@ -1,5 +1,26 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { iteratorReduce } = require('iter-fest/iteratorReduce');
+const { iteratorTake } = require('iter-fest/iteratorTake');
 
-test('iteratorReduce should work', () =>
-  expect(iteratorReduce([1, 2, 3].values(), (previousValue, currentValue) => previousValue + currentValue, 0)).toBe(6));
+test('iteratorReduce should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorReduce(
+    iteratorTake(naturals(), 5),
+    (sum, value) => {
+      return sum + value;
+    },
+    3
+  );
+
+  expect(result).toBe(13);
+});

--- a/packages/integration-test/requireNamed/iteratorSome.test.ts
+++ b/packages/integration-test/requireNamed/iteratorSome.test.ts
@@ -1,4 +1,24 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { iteratorSome } = require('iter-fest/iteratorSome');
+const { iteratorTake } = require('iter-fest/iteratorTake');
 
-test('iteratorSome should work', () => expect(iteratorSome([1, 2, 3].values(), value => value % 2)).toBe(true));
+test('iteratorSome should work', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const iter = iteratorTake(naturals(), 4);
+
+  expect(iteratorSome(iter, v => v > 1)).toEqual(true);
+  expect(iteratorSome(iter, () => true)).toEqual(false); // iterator is already consumed.
+
+  expect(iteratorSome(iteratorTake(naturals(), 4), v => v > 1)).toEqual(true);
+  expect(iteratorSome(iteratorTake(naturals(), 4), v => v == 1)).toEqual(true); // acting on a new iterator
+});

--- a/packages/iter-fest/src/iteratorEvery.spec.ts
+++ b/packages/iter-fest/src/iteratorEvery.spec.ts
@@ -1,4 +1,5 @@
 import { iteratorEvery } from './iteratorEvery';
+import { iteratorTake } from './iteratorTake';
 
 describe.each([[[1, 2, 3]], [[]]])('when compare to %s.every()', array => {
   let arrayPredicate: jest.Mock<unknown, [number, number, number[]]>;
@@ -40,3 +41,22 @@ describe.each([[[1, 2, 3]], [[]]])('when compare to %s.every()', array => {
 test('should throw TypeError when passing an invalid callbackFn', () =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expect(() => iteratorEvery([].values(), 0 as any)).toThrow('is not a function'));
+
+test('should work with TC39 sample', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+    while (true) {
+      yield i;
+      i += 1;
+    }
+  }
+
+  const iter = iteratorTake(naturals(), 10);
+
+  expect(iteratorEvery(iter, v => v >= 0)).toBe(true);
+  expect(iteratorEvery(iter, () => false)).toBe(true); // iterator is already consumed.
+
+  expect(iteratorEvery(iteratorTake(naturals(), 4), v => v > 0)).toEqual(false); // first value is 0
+  expect(iteratorEvery(iteratorTake(naturals(), 4), v => v >= 0)).toEqual(true); // acting on a new iterator
+});

--- a/packages/iter-fest/src/iteratorFilter.spec.ts
+++ b/packages/iter-fest/src/iteratorFilter.spec.ts
@@ -40,3 +40,24 @@ describe.each([[[1, 2, 3]], [[]]])('when compare to %s.filter()', array => {
 test('should throw TypeError when passing an invalid callbackFn', () =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expect(() => iteratorFilter([].values(), 0 as any).next()).toThrow('is not a function'));
+
+test('should work with TC39 sample', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorFilter(naturals(), value => {
+    return value % 2 == 0;
+  });
+
+  expect(result.next()).toEqual({ done: false, value: 0 });
+  expect(result.next()).toEqual({ done: false, value: 2 });
+  expect(result.next()).toEqual({ done: false, value: 4 });
+});

--- a/packages/iter-fest/src/iteratorFind.spec.ts
+++ b/packages/iter-fest/src/iteratorFind.spec.ts
@@ -40,3 +40,18 @@ describe.each([[[1, 2, 3]], [[]]])('when compare to %s.find()', array => {
 test('should throw TypeError when passing an invalid callbackFn', () =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expect(() => iteratorFind([].values(), 0 as any)).toThrow('is not a function'));
+
+test('should work with TC39 sample', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  expect(iteratorFind(naturals(), v => v > 1)).toBe(2);
+});

--- a/packages/iter-fest/src/iteratorForEach.spec.ts
+++ b/packages/iter-fest/src/iteratorForEach.spec.ts
@@ -36,3 +36,14 @@ describe.each([[[1, 2, 3]], [[]]])('when compare to %s.map()', array => {
 test('should throw TypeError when passing an invalid callbackfn', () =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expect(() => iteratorForEach([].values(), 0 as any)).toThrow('is not a function'));
+
+test('should work with TC39 sample', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  const log: number[] = [];
+  const fn = (value: number) => log.push(value);
+  const iter = [1, 2, 3].values();
+
+  iteratorForEach(iter, fn);
+
+  expect(log.join(', ')).toBe('1, 2, 3');
+});

--- a/packages/iter-fest/src/iteratorMap.spec.ts
+++ b/packages/iter-fest/src/iteratorMap.spec.ts
@@ -40,3 +40,24 @@ describe.each([[[1, 2, 3]], [[]]])('when compare to %s.map()', array => {
 test('should throw TypeError when passing an invalid callbackfn', () =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expect(() => iteratorMap([].values(), 0 as any).next()).toThrow('is not a function'));
+
+test('should work with TC39 sample', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorMap(naturals(), value => {
+    return value * value;
+  });
+
+  expect(result.next()).toEqual({ done: false, value: 0 });
+  expect(result.next()).toEqual({ done: false, value: 1 });
+  expect(result.next()).toEqual({ done: false, value: 4 });
+});

--- a/packages/iter-fest/src/iteratorReduce.spec.ts
+++ b/packages/iter-fest/src/iteratorReduce.spec.ts
@@ -1,4 +1,5 @@
 import { iteratorReduce } from './iteratorReduce';
+import { iteratorTake } from './iteratorTake';
 
 describe.each([[[1, 2, 3]], [[]]])('when compare to %s.reduce()', array => {
   let arrayReducer: jest.Mock<string, [string, number, number, number[]]>;
@@ -40,3 +41,26 @@ describe.each([[[1, 2, 3]], [[]]])('when compare to %s.reduce()', array => {
 test('should throw TypeError when passing an invalid callbackfn', () =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expect(() => iteratorReduce([].values(), 0 as any)).toThrow('is not a function'));
+
+test('should work with TC39 sample', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const result = iteratorReduce(
+    iteratorTake(naturals(), 5),
+    (sum, value) => {
+      return sum + value;
+    },
+    3
+  );
+
+  expect(result).toBe(13);
+});

--- a/packages/iter-fest/src/iteratorSome.spec.ts
+++ b/packages/iter-fest/src/iteratorSome.spec.ts
@@ -1,4 +1,5 @@
 import { iteratorSome } from './iteratorSome';
+import { iteratorTake } from './iteratorTake';
 
 describe.each([[[1, 2, 3]], [[]]])('when compare to %s.some()', array => {
   let arrayPredicate: jest.Mock<unknown, [number, number, number[]]>;
@@ -40,3 +41,24 @@ describe.each([[[1, 2, 3]], [[]]])('when compare to %s.some()', array => {
 test('should throw TypeError when passing an invalid predicate', () =>
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expect(() => iteratorSome([].values(), 0 as any)).toThrow('is not a function'));
+
+test('should work with TC39 sample', () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  function* naturals() {
+    let i = 0;
+
+    while (true) {
+      yield i;
+
+      i += 1;
+    }
+  }
+
+  const iter = iteratorTake(naturals(), 4);
+
+  expect(iteratorSome(iter, v => v > 1)).toEqual(true);
+  expect(iteratorSome(iter, () => true)).toEqual(false); // iterator is already consumed.
+
+  expect(iteratorSome(iteratorTake(naturals(), 4), v => v > 1)).toEqual(true);
+  expect(iteratorSome(iteratorTake(naturals(), 4), v => v == 1)).toEqual(true); // acting on a new iterator
+});


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Added `iteratorDrop`, `iteratorFlatMap`, `iteratorFrom`, `iteratorTake`, `iteratorToArray` in PR [#24](https://github.com/compulim/iter-fest/pull/24) and [#25](https://github.com/compulim/iter-fest/pull/25)

### Changed

- Following functions will be using ponyfill from `core-js-pure` with types, in PR [#24](https://github.com/compulim/iter-fest/pull/24) and [#25](https://github.com/compulim/iter-fest/pull/25)
   - `iteratorEvery`, `iteratorFilter`, `iteratorFind`, `iteratorForEach`, `iteratorMap`, `iteratorReduce`, `iteratorSome`

## Specific changes

> Please list each individual specific change in this pull request.

- Added tests from TC39 proposal sample