### PR TITLE
Add `asyncIteratorFrom`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `generatorWithLastValue`/`asyncGeneratorWithLastValue` in PR [#17](https://github.com/compulim/iter-fest/pull/17)
 - Added `asyncIteratorToAsyncIterable` in PR [#18](https://github.com/compulim/iter-fest/pull/18)
 - Added `iteratorDrop`, `iteratorFlatMap`, `iteratorFrom`, `iteratorTake`, `iteratorToArray` in PR [#24](https://github.com/compulim/iter-fest/pull/24) and [#25](https://github.com/compulim/iter-fest/pull/25)
-- Added [Async Iterator Helpers](https://github.com/tc39/proposal-async-iterator-helpers) from `core-js-pure` as `asyncIterator*` in PR [#28](https://github.com/compulim/iter-fest/pull/28)
+- Added [Async Iterator Helpers](https://github.com/tc39/proposal-async-iterator-helpers) from `core-js-pure` as `asyncIterator*` in PR [#28](https://github.com/compulim/iter-fest/pull/28) and [#29](https://github.com/compulim/iter-fest/pull/29)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Note: calling `[Symbol.iterator]()` or `[Symbol.asyncIterator]()` will not resta
 
 `ReadableStream` can be used as an intermediate format when converting an `Observable` to `AsyncIterableIterator`.
 
-Note: `Observable` is push-based and it does not support flow control. When converting to `AsyncIterableIteratorrr`, the internal buffer of `ReadableStream` could build up quickly.
+Note: `Observable` is push-based and it does not support flow control. When converting to `AsyncIterableIterator`, the internal buffer of `ReadableStream` could build up quickly.
 
 ```ts
 const observable = Observable.from([1, 2, 3]);

--- a/packages/integration-test/importDefault/asyncIteratorFrom.test.ts
+++ b/packages/integration-test/importDefault/asyncIteratorFrom.test.ts
@@ -1,0 +1,15 @@
+import { asyncIteratorFrom } from 'iter-fest';
+
+test('asyncIteratorFrom should work', async () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  class Iter {
+    next() {
+      return Promise.resolve({ done: false, value: 1 });
+    }
+  }
+
+  const iter = new Iter();
+  const wrapper = asyncIteratorFrom(iter);
+
+  await expect(wrapper.next()).resolves.toEqual({ done: false, value: 1 });
+});

--- a/packages/integration-test/importDefault/iteratorFrom.test.ts
+++ b/packages/integration-test/importDefault/iteratorFrom.test.ts
@@ -1,6 +1,6 @@
 import { iteratorFrom } from 'iter-fest';
 
-test('iteratorFrom', () => {
+test('iteratorFrom should work', () => {
   // Copied from https://github.com/tc39/proposal-iterator-helpers.
   class Iter {
     next() {

--- a/packages/integration-test/importNamed/asyncIteratorFrom.test.ts
+++ b/packages/integration-test/importNamed/asyncIteratorFrom.test.ts
@@ -1,0 +1,15 @@
+import { asyncIteratorFrom } from 'iter-fest/asyncIteratorFrom';
+
+test('asyncIteratorFrom should work', async () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  class Iter {
+    next() {
+      return Promise.resolve({ done: false, value: 1 });
+    }
+  }
+
+  const iter = new Iter();
+  const wrapper = asyncIteratorFrom(iter);
+
+  await expect(wrapper.next()).resolves.toEqual({ done: false, value: 1 });
+});

--- a/packages/integration-test/importNamed/iteratorFrom.test.ts
+++ b/packages/integration-test/importNamed/iteratorFrom.test.ts
@@ -1,6 +1,6 @@
 import { iteratorFrom } from 'iter-fest/iteratorFrom';
 
-test('iteratorFrom', () => {
+test('iteratorFrom should work', () => {
   // Copied from https://github.com/tc39/proposal-iterator-helpers.
   class Iter {
     next() {

--- a/packages/integration-test/requireDefault/asyncIteratorFrom.test.ts
+++ b/packages/integration-test/requireDefault/asyncIteratorFrom.test.ts
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { asyncIteratorFrom } = require('iter-fest');
+
+test('asyncIteratorFrom should work', async () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  class Iter {
+    next() {
+      return Promise.resolve({ done: false, value: 1 });
+    }
+  }
+
+  const iter = new Iter();
+  const wrapper = asyncIteratorFrom(iter);
+
+  await expect(wrapper.next()).resolves.toEqual({ done: false, value: 1 });
+});

--- a/packages/integration-test/requireDefault/iteratorFrom.test.ts
+++ b/packages/integration-test/requireDefault/iteratorFrom.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { iteratorFrom } = require('iter-fest');
 
-test('iteratorFrom', () => {
+test('iteratorFrom should work', () => {
   // Copied from https://github.com/tc39/proposal-iterator-helpers.
   class Iter {
     next() {

--- a/packages/integration-test/requireNamed/asyncIteratorFrom.test.ts
+++ b/packages/integration-test/requireNamed/asyncIteratorFrom.test.ts
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { asyncIteratorFrom } = require('iter-fest/asyncIteratorFrom');
+
+test('asyncIteratorFrom should work', async () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  class Iter {
+    next() {
+      return Promise.resolve({ done: false, value: 1 });
+    }
+  }
+
+  const iter = new Iter();
+  const wrapper = asyncIteratorFrom(iter);
+
+  await expect(wrapper.next()).resolves.toEqual({ done: false, value: 1 });
+});

--- a/packages/integration-test/requireNamed/iteratorFrom.test.ts
+++ b/packages/integration-test/requireNamed/iteratorFrom.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { iteratorFrom } = require('iter-fest/iteratorFrom');
 
-test('iteratorFrom', () => {
+test('iteratorFrom should work', () => {
   // Copied from https://github.com/tc39/proposal-iterator-helpers.
   class Iter {
     next() {

--- a/packages/iter-fest/package.json
+++ b/packages/iter-fest/package.json
@@ -76,6 +76,16 @@
         "default": "./dist/iter-fest.asyncIteratorForEach.js"
       }
     },
+    "./asyncIteratorFrom": {
+      "import": {
+        "types": "./dist/iter-fest.asyncIteratorFrom.d.mts",
+        "default": "./dist/iter-fest.asyncIteratorFrom.mjs"
+      },
+      "require": {
+        "types": "./dist/iter-fest.asyncIteratorFrom.d.ts",
+        "default": "./dist/iter-fest.asyncIteratorFrom.js"
+      }
+    },
     "./asyncIteratorMap": {
       "import": {
         "types": "./dist/iter-fest.asyncIteratorMap.d.mts",

--- a/packages/iter-fest/src/asyncIteratorFrom.spec.ts
+++ b/packages/iter-fest/src/asyncIteratorFrom.spec.ts
@@ -1,0 +1,15 @@
+import { asyncIteratorFrom } from './asyncIteratorFrom';
+
+test('should follow TC39 proposal sample (sync)', async () => {
+  // Copied from https://github.com/tc39/proposal-iterator-helpers.
+  class Iter {
+    next() {
+      return Promise.resolve({ done: false, value: 1 });
+    }
+  }
+
+  const iter = new Iter();
+  const wrapper = asyncIteratorFrom(iter);
+
+  await expect(wrapper.next()).resolves.toEqual({ done: false, value: 1 });
+});

--- a/packages/iter-fest/src/asyncIteratorFrom.ts
+++ b/packages/iter-fest/src/asyncIteratorFrom.ts
@@ -1,5 +1,5 @@
 // @ts-expect-error core-js-pure is not typed.
-import from from 'core-js-pure/full/iterator/from';
+import from from 'core-js-pure/full/async-iterator/from';
 
 /**
  * `.from` is a static method (unlike the others listed above) which takes an object as an argument. This method allows wrapping "iterator-like" objects with an iterator.
@@ -8,6 +8,6 @@ import from from 'core-js-pure/full/iterator/from';
  *
  * @link https://github.com/tc39/proposal-iterator-helpers/blob/main/README.md
  */
-export function iteratorFrom<T>(iteratorLike: Iterator<T>): Iterator<T> {
-  return from(iteratorLike);
+export function asyncIteratorFrom<T>(asyncIteratorLike: Pick<AsyncIterator<T>, 'next'>): AsyncIterator<T> {
+  return from(asyncIteratorLike);
 }

--- a/packages/iter-fest/src/index.ts
+++ b/packages/iter-fest/src/index.ts
@@ -7,6 +7,7 @@ export * from './asyncIteratorFilter';
 export * from './asyncIteratorFind';
 export * from './asyncIteratorFlatMap';
 export * from './asyncIteratorForEach';
+export * from './asyncIteratorFrom';
 export * from './asyncIteratorMap';
 export * from './asyncIteratorReduce';
 export * from './asyncIteratorSome';

--- a/packages/iter-fest/tsup.config.ts
+++ b/packages/iter-fest/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig([
       'iter-fest.asyncIteratorFind': './src/asyncIteratorFind.ts',
       'iter-fest.asyncIteratorFlatMap': './src/asyncIteratorFlatMap.ts',
       'iter-fest.asyncIteratorForEach': './src/asyncIteratorForEach.ts',
+      'iter-fest.asyncIteratorFrom': './src/asyncIteratorFrom.ts',
       'iter-fest.asyncIteratorMap': './src/asyncIteratorMap.ts',
       'iter-fest.asyncIteratorReduce': './src/asyncIteratorReduce.ts',
       'iter-fest.asyncIteratorSome': './src/asyncIteratorSome.ts',


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Added [Async Iterator Helpers](https://github.com/tc39/proposal-async-iterator-helpers) from `core-js-pure` as `asyncIterator*` in PR [#28](https://github.com/compulim/iter-fest/pull/28) and [#29](https://github.com/compulim/iter-fest/pull/29)

## Specific changes

> Please list each individual specific change in this pull request.

- Added `asyncIteratorFrom`