### PR TITLE
Rename `readerValues` to `readableStreamValues`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `asyncIteratorToAsyncIterable` in PR [#18](https://github.com/compulim/iter-fest/pull/18)
 - Added `iteratorDrop`, `iteratorFlatMap`, `iteratorFrom`, `iteratorTake`, `iteratorToArray` in PR [#24](https://github.com/compulim/iter-fest/pull/24) and [#25](https://github.com/compulim/iter-fest/pull/25)
 - Added [Async Iterator Helpers](https://github.com/tc39/proposal-async-iterator-helpers) from `core-js-pure` as `asyncIterator*` in PR [#28](https://github.com/compulim/iter-fest/pull/28) and [#29](https://github.com/compulim/iter-fest/pull/29)
+- Added `observableValues` in PR [#30](https://github.com/compulim/iter-fest/pull/30)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed `Observable` from `core-js-pure`, in PR [#8](https://github.com/compulim/iter-fest/pull/8)
 - Added `observableFromAsync` to convert `AsyncIterable` into `Observable` in PR [#9](https://github.com/compulim/iter-fest/pull/9)
 - Added `IterableWritableStream` in PR [#11](https://github.com/compulim/iter-fest/pull/11) and [#23](https://github.com/compulim/iter-fest/pull/23)
-- Added `readableStreamValues` in PR [#12](https://github.com/compulim/iter-fest/pull/12), [#14](https://github.com/compulim/iter-fest/pull/14), and [#XXX](https://github.com/compulim/iter-fest/pull/XXX)
+- Added `readableStreamValues` in PR [#12](https://github.com/compulim/iter-fest/pull/12), [#14](https://github.com/compulim/iter-fest/pull/14), and [#30](https://github.com/compulim/iter-fest/pull/30)
 - Added `observableSubscribeAsReadable` in PR [#13](https://github.com/compulim/iter-fest/pull/13)
 - Added `readableStreamFrom` in PR [#15](https://github.com/compulim/iter-fest/pull/15) and [#22](https://github.com/compulim/iter-fest/pull/22)
 - Added `generatorWithLastValue`/`asyncGeneratorWithLastValue` in PR [#17](https://github.com/compulim/iter-fest/pull/17)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added typed `Observable` from `core-js-pure`, in PR [#8](https://github.com/compulim/iter-fest/pull/8)
 - Added `observableFromAsync` to convert `AsyncIterable` into `Observable` in PR [#9](https://github.com/compulim/iter-fest/pull/9)
 - Added `IterableWritableStream` in PR [#11](https://github.com/compulim/iter-fest/pull/11) and [#23](https://github.com/compulim/iter-fest/pull/23)
-- Added `readerValues` in PR [#12](https://github.com/compulim/iter-fest/pull/12) and [#14](https://github.com/compulim/iter-fest/pull/14)
+- Added `readableStreamValues` in PR [#12](https://github.com/compulim/iter-fest/pull/12), [#14](https://github.com/compulim/iter-fest/pull/14), and [#XXX](https://github.com/compulim/iter-fest/pull/XXX)
 - Added `observableSubscribeAsReadable` in PR [#13](https://github.com/compulim/iter-fest/pull/13)
 - Added `readableStreamFrom` in PR [#15](https://github.com/compulim/iter-fest/pull/15) and [#22](https://github.com/compulim/iter-fest/pull/22)
 - Added `generatorWithLastValue`/`asyncGeneratorWithLastValue` in PR [#17](https://github.com/compulim/iter-fest/pull/17)

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Note: `readableStreamFrom()` will call `[Symbol.iterator]()` initially to restar
 observableValues<T>(observable: Observable<T>): AsyncIterableIterator<T>;
 ```
 
-`Observable` can be converted to `AsyncIterableIterator` for easier consumption. However, `Observable` is push-based and it does not support flow control. When converting to `AsyncIterableIterator`, the internal buffer could build up quickly.
+`Observable` can be converted to `AsyncIterableIterator` for easier consumption.
 
 ```ts
 const observable = Observable.from([1, 2, 3]);
@@ -167,6 +167,8 @@ for await (const value of iterable) {
   console.log(value); // Prints "1", "2", "3".
 }
 ```
+
+Note: `Observable` is push-based and it does not support flow control. When converting to `AsyncIterableIterator`, the internal buffer could build up quickly.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ for await (const value of iterable) {
 
 Note: `Observable` is push-based and it does not support flow control. When converting to `AsyncIterableIterator`, the internal buffer could build up quickly.
 
-Note: When the observable throw an exception via `observer.error()`, it will become rejection of `AsyncIterator.next()`. The exception will be hoisted back to the caller.
+Note: when the observable throw an exception via `observer.error()`, it will become rejection of `AsyncIterator.next()`. The exception will be hoisted back to the caller.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ for await (const value of iterable) {
 
 Note: The stream will be locked as soon as the iterable is created. When using iterating outside of for-loop, make sure to call `AsyncIterator.return` when the iteration is done to release the lock on the stream.
 
-Note: `[Symbol.asyncIterator]()` will not restart the reader and read from start of the stream. Reader is not restartable and streams are not seekable.
+Note: `[Symbol.asyncIterator]()` will not restart the stream.
 
 ### Converting an `AsyncIterable`/`Iterable` to `ReadableStream`
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ observableValues<T>(observable: Observable<T>): AsyncIterableIterator<T>;
 
 `Observable` can be converted to `AsyncIterableIterator` for easier consumption.
 
+When the observable throw an exception via `observer.error()`, it will become rejection of `AsyncIterator.next()`. The exception will be hoisted back to the caller.
+
 ```ts
 const observable = Observable.from([1, 2, 3]);
 const iterable = observableValues(readable);

--- a/README.md
+++ b/README.md
@@ -60,24 +60,6 @@ for (const value of iteratorToIterable(iterate())) {
 
 Note: calling `[Symbol.iterator]()` or `[Symbol.asyncIterator]()` will not restart the iteration. This is because iterator is an instance of iteration and is not restartable.
 
-### Converting an `Observable` to `AsyncIterableIterator`
-
-`ReadableStream` can be used as an intermediate format when converting an `Observable` to `AsyncIterableIterator`.
-
-```ts
-const observable = Observable.from([1, 2, 3]);
-const readable = observableSubscribeAsReadable(observable);
-const iterable = readableStreamValues(readable);
-
-for await (const value of iterable) {
-  console.log(value); // Prints "1", "2", "3".
-}
-```
-
-Note: `Observable` is push-based and it does not support flow control. When converting to `AsyncIterableIterator`, the internal buffer of `ReadableStream` could build up quickly.
-
-Note: calling `[Symbol.asyncIterator]()` will not resubscribe and read from the start of the observable. This is because the intermediate format does not support restart.
-
 ### Converting an `AsyncIterable` to `Observable`
 
 ```ts
@@ -169,6 +151,24 @@ readable.pipeTo(stream.writable); // Will write 1, 2, 3.
 ```
 
 Note: `readableStreamFrom()` will call `[Symbol.iterator]()` initially to restart the iteration where possible.
+
+### Converting an `Observable` to `AsyncIterableIterator`
+
+`ReadableStream` can be used as an intermediate format when converting an `Observable` to `AsyncIterableIterator`.
+
+```ts
+const observable = Observable.from([1, 2, 3]);
+const readable = observableSubscribeAsReadable(observable);
+const iterable = readableStreamValues(readable);
+
+for await (const value of iterable) {
+  console.log(value); // Prints "1", "2", "3".
+}
+```
+
+Note: `Observable` is push-based and it does not support flow control. When converting to `AsyncIterableIterator`, the internal buffer of `ReadableStream` could build up quickly.
+
+Note: calling `[Symbol.asyncIterator]()` will not resubscribe and read from the start of the observable. This is because the intermediate format does not support restart.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -159,8 +159,6 @@ observableValues<T>(observable: Observable<T>): AsyncIterableIterator<T>;
 
 `Observable` can be converted to `AsyncIterableIterator` for easier consumption.
 
-When the observable throw an exception via `observer.error()`, it will become rejection of `AsyncIterator.next()`. The exception will be hoisted back to the caller.
-
 ```ts
 const observable = Observable.from([1, 2, 3]);
 const iterable = observableValues(readable);
@@ -171,6 +169,8 @@ for await (const value of iterable) {
 ```
 
 Note: `Observable` is push-based and it does not support flow control. When converting to `AsyncIterableIterator`, the internal buffer could build up quickly.
+
+Note: When the observable throw an exception via `observer.error()`, it will become rejection of `AsyncIterator.next()`. The exception will be hoisted back to the caller.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ npm install iter-fest
 ### Converting an iterator to iterable
 
 ```ts
-iteratorToIterable<T>(iterator: Iterator<T>): IterableIterator<T>
-asyncIteratorToAsyncIterable<T>(asyncIterator: AsyncIterator<T>): AsyncIterableIterator<T>
+function iteratorToIterable<T>(iterator: Iterator<T>): IterableIterator<T>
+
+function asyncIteratorToAsyncIterable<T>(asyncIterator: AsyncIterator<T>): AsyncIterableIterator<T>
 ```
 
 `iteratorToIterable` and `asyncIteratorToAsyncIterable` enable a [pure iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) to be iterable using a for-loop statement.
@@ -62,7 +63,7 @@ Note: calling `[Symbol.iterator]()` or `[Symbol.asyncIterator]()` will not resta
 ### Converting an `AsyncIterable` to `Observable`
 
 ```ts
-observableFromAsync<T>(iterable: AsyncIterable<T>): Observable<T>
+function observableFromAsync<T>(iterable: AsyncIterable<T>): Observable<T>
 ```
 
 `Observable.from` converts `Iterable` into `Observable`. However, it does not convert `AsyncIterable`.
@@ -89,7 +90,7 @@ Note: It is not recommended to convert `AsyncGenerator` to an `Observable`. `Asy
 ### Converting an `Observable` to `ReadableStream`
 
 ```ts
-observableSubscribeAsReadable<T>(observable: Observable<T>): ReadableStream<T>
+function observableSubscribeAsReadable<T>(observable: Observable<T>): ReadableStream<T>
 ```
 
 `ReadableStream` is powerful for transforming and piping stream of data. It can be formed using data from both push-based and pull-based source with backpressuree.
@@ -106,7 +107,7 @@ readable.pipeTo(stream.writable); // Will write 1, 2, 3.
 ### Converting a `ReadableStream` to `AsyncIterableIterator`
 
 ```ts
-readableStreamValues`<T>(readable: ReadableStream<T>): AsyncIterableIterator<T>
+function readableStreamValues`<T>(readable: ReadableStream<T>): AsyncIterableIterator<T>
 ```
 
 `readableStreamValues` allow iteration of `ReadableStream` as an `AsyncIterableIterator`.
@@ -137,7 +138,7 @@ Note: `[Symbol.asyncIterator]()` will not restart the stream.
 ### Converting an `AsyncIterable`/`Iterable` to `ReadableStream`
 
 ```ts
-readableStreamFrom<T>(anyIterable: AsyncIterable<T> | Iterable<T>): ReadableStream<T>
+function readableStreamFrom<T>(anyIterable: AsyncIterable<T> | Iterable<T>): ReadableStream<T>
 ```
 
 > Notes: this feature is part of [Streams Standard](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/from_static).
@@ -154,7 +155,7 @@ Note: `readableStreamFrom()` will call `[Symbol.iterator]()` initially to restar
 ### Converting an `Observable` to `AsyncIterableIterator`
 
 ```ts
-observableValues<T>(observable: Observable<T>): AsyncIterableIterator<T>;
+function observableValues<T>(observable: Observable<T>): AsyncIterableIterator<T>
 ```
 
 `Observable` can be converted to `AsyncIterableIterator` for easier consumption.

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ npm install iter-fest
 | `ReadableStream`           | `AsyncIterableIterator` | [`readableStreamValues`](#converting-a-readablestream-to-asynciterableiterator) |
 | `AsyncIterable`            | `Observable`            | [`observableFromAsync`](#converting-an-asynciterable-to-observable)             |
 | `AsyncIterable`/`Iterable` | `ReadableStream`        | [`readableStreamFrom`](#converting-an-asynciterableiterable-to-readablestream)  |
-
-To convert `Observable` to `AsyncIterableIterator`, [use `ReadableStream` as intermediate format](#converting-an-observable-to-asynciterableiterator).
+| `Observable`               | `AsyncIterableIterator` | [`observableValues`](#converting-an-observable-to-asynciterableiterator)        |
 
 ### Converting an iterator to iterable
 
@@ -154,21 +153,20 @@ Note: `readableStreamFrom()` will call `[Symbol.iterator]()` initially to restar
 
 ### Converting an `Observable` to `AsyncIterableIterator`
 
-`ReadableStream` can be used as an intermediate format when converting an `Observable` to `AsyncIterableIterator`.
+```ts
+observableValues<T>(observable: Observable<T>): AsyncIterableIterator<T>;
+```
+
+`Observable` can be converted to `AsyncIterableIterator` for easier consumption. However, `Observable` is push-based and it does not support flow control. When converting to `AsyncIterableIterator`, the internal buffer could build up quickly.
 
 ```ts
 const observable = Observable.from([1, 2, 3]);
-const readable = observableSubscribeAsReadable(observable);
-const iterable = readableStreamValues(readable);
+const iterable = observableValues(readable);
 
 for await (const value of iterable) {
   console.log(value); // Prints "1", "2", "3".
 }
 ```
-
-Note: `Observable` is push-based and it does not support flow control. When converting to `AsyncIterableIterator`, the internal buffer of `ReadableStream` could build up quickly.
-
-Note: calling `[Symbol.asyncIterator]()` will not resubscribe and read from the start of the observable. This is because the intermediate format does not support restart.
 
 ## Others
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ npm install iter-fest
 
 ## Conversions
 
-| From                          | To                      | Function                                                                                     |
-| ----------------------------- | ----------------------- | -------------------------------------------------------------------------------------------- |
-| `Iterator`                    | `IterableIterator`      | [`iteratorToIterable`](#converting-an-iterator-to-iterable)                                  |
-| `AsyncIterator`               | `AsyncIterableIterator` | [`asyncIteratorToAsyncIterable`](#converting-an-iterator-to-iterable)                        |
-| `Observable`                  | `ReadableStream`        | [`observableSubscribeAsReadable`](#converting-an-observable-to-readablestream)               |
-| `ReadableStreamDefaultReader` | `AsyncIterableIterator` | [`readableStreamValues`](#converting-a-readablestreamdefaultreader-to-asynciterableiterator) |
-| `AsyncIterable`               | `Observable`            | [`observableFromAsync`](#converting-an-asynciterable-to-observable)                          |
-| `AsyncIterable`/`Iterable`    | `ReadableStream`        | [`readableStreamFrom`](#converting-an-asynciterableiterable-to-readablestream)               |
+| From                       | To                      | Function                                                                        |
+| -------------------------- | ----------------------- | ------------------------------------------------------------------------------- |
+| `Iterator`                 | `IterableIterator`      | [`iteratorToIterable`](#converting-an-iterator-to-iterable)                     |
+| `AsyncIterator`            | `AsyncIterableIterator` | [`asyncIteratorToAsyncIterable`](#converting-an-iterator-to-iterable)           |
+| `Observable`               | `ReadableStream`        | [`observableSubscribeAsReadable`](#converting-an-observable-to-readablestream)  |
+| `ReadableStream`           | `AsyncIterableIterator` | [`readableStreamValues`](#converting-a-readablestream-to-asynciterableiterator) |
+| `AsyncIterable`            | `Observable`            | [`observableFromAsync`](#converting-an-asynciterable-to-observable)             |
+| `AsyncIterable`/`Iterable` | `ReadableStream`        | [`readableStreamFrom`](#converting-an-asynciterableiterable-to-readablestream)  |
 
 To convert `Observable` to `AsyncIterableIterator`, [use `ReadableStream` as intermediate format](#converting-an-observable-to-asynciterableiterator).
 
@@ -104,7 +104,7 @@ const readable = observableSubscribeAsReadable(observable);
 readable.pipeTo(stream.writable); // Will write 1, 2, 3.
 ```
 
-### Converting a `ReadableStreamDefaultReader` to `AsyncIterableIterator`
+### Converting a `ReadableStream` to `AsyncIterableIterator`
 
 ```ts
 readableStreamValues`<T>(readable: ReadableStream<T>): AsyncIterableIterator<T>

--- a/README.md
+++ b/README.md
@@ -18,18 +18,23 @@ npm install iter-fest
 
 ## Conversions
 
-| From                          | To                      | Function signature                                                                                                                                         |
-| ----------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Iterator`                    | `IterableIterator`      | [`iteratorToIterable<T>(iterator: Iterator<T>): IterableIterator<T>`](#converting-an-iterator-to-iterable)                                                 |
-| `AsyncIterator`               | `AsyncIterableIterator` | [`asyncIteratorToAsyncIterable<T>(asyncIterator: AsyncIterator<T>): AsyncIterableIterator<T>`](#converting-an-iterator-to-iterable)                        |
-| `Observable`                  | `ReadableStream`        | [`observableSubscribeAsReadable<T>(observable: Observable<T>): ReadableStream<T>`](#converting-an-observable-to-readablestream)                            |
-| `ReadableStreamDefaultReader` | `AsyncIterableIterator` | [`readerValues`<T>(reader: ReadableStreamDefaultReader<T>): AsyncIterableIterator<T>`](#converting-a-readablestreamdefaultreader-to-asynciterableiterator) |
-| `AsyncIterable`               | `Observable`            | [`observableFromAsync<T>(iterable: AsyncIterable<T>): Observable<T>`](#converting-an-asynciterable-to-observable)                                          |
-| `AsyncIterable`/`Iterable`    | `ReadableStream`        | [`readableStreamFrom<T>(anyIterable: AsyncIterable<T> \| Iterable<T>): ReadableStream<T>`](#converting-an-asynciterableiterable-to-readablestream)         |
+| From                          | To                      | Function                                                                                     |
+| ----------------------------- | ----------------------- | -------------------------------------------------------------------------------------------- |
+| `Iterator`                    | `IterableIterator`      | [`iteratorToIterable`](#converting-an-iterator-to-iterable)                                  |
+| `AsyncIterator`               | `AsyncIterableIterator` | [`asyncIteratorToAsyncIterable`](#converting-an-iterator-to-iterable)                        |
+| `Observable`                  | `ReadableStream`        | [`observableSubscribeAsReadable`](#converting-an-observable-to-readablestream)               |
+| `ReadableStreamDefaultReader` | `AsyncIterableIterator` | [`readableStreamValues`](#converting-a-readablestreamdefaultreader-to-asynciterableiterator) |
+| `AsyncIterable`               | `Observable`            | [`observableFromAsync`](#converting-an-asynciterable-to-observable)                          |
+| `AsyncIterable`/`Iterable`    | `ReadableStream`        | [`readableStreamFrom`](#converting-an-asynciterableiterable-to-readablestream)               |
 
 To convert `Observable` to `AsyncIterableIterator`, [use `ReadableStream` as intermediate format](#converting-an-observable-to-asynciterableiterator).
 
 ### Converting an iterator to iterable
+
+```ts
+iteratorToIterable<T>(iterator: Iterator<T>): IterableIterator<T>
+asyncIteratorToAsyncIterable<T>(asyncIterator: AsyncIterator<T>): AsyncIterableIterator<T>
+```
 
 `iteratorToIterable` and `asyncIteratorToAsyncIterable` enable a [pure iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) to be iterable using a for-loop statement.
 
@@ -59,21 +64,25 @@ Note: calling `[Symbol.iterator]()` or `[Symbol.asyncIterator]()` will not resta
 
 `ReadableStream` can be used as an intermediate format when converting an `Observable` to `AsyncIterableIterator`.
 
-Note: `Observable` is push-based and it does not support flow control. When converting to `AsyncIterableIterator`, the internal buffer of `ReadableStream` could build up quickly.
-
 ```ts
 const observable = Observable.from([1, 2, 3]);
 const readable = observableSubscribeAsReadable(observable);
-const iterable = readerValues(readable.getReader());
+const iterable = readableStreamValues(readable);
 
 for await (const value of iterable) {
   console.log(value); // Prints "1", "2", "3".
 }
 ```
 
+Note: `Observable` is push-based and it does not support flow control. When converting to `AsyncIterableIterator`, the internal buffer of `ReadableStream` could build up quickly.
+
 Note: calling `[Symbol.asyncIterator]()` will not resubscribe and read from the start of the observable. This is because the intermediate format does not support restart.
 
 ### Converting an `AsyncIterable` to `Observable`
+
+```ts
+observableFromAsync<T>(iterable: AsyncIterable<T>): Observable<T>
+```
 
 `Observable.from` converts `Iterable` into `Observable`. However, it does not convert `AsyncIterable`.
 
@@ -98,6 +107,10 @@ Note: It is not recommended to convert `AsyncGenerator` to an `Observable`. `Asy
 
 ### Converting an `Observable` to `ReadableStream`
 
+```ts
+observableSubscribeAsReadable<T>(observable: Observable<T>): ReadableStream<T>
+```
+
 `ReadableStream` is powerful for transforming and piping stream of data. It can be formed using data from both push-based and pull-based source with backpressuree.
 
 Note: `Observable` is push-based and it does not support flow control. When converting to `ReadableStream`, the internal buffer could build up quickly.
@@ -111,10 +124,14 @@ readable.pipeTo(stream.writable); // Will write 1, 2, 3.
 
 ### Converting a `ReadableStreamDefaultReader` to `AsyncIterableIterator`
 
-`readerValues` will convert default reader of `ReadableStream` into an `AsyncIterableIterator` to use in for-loop.
+```ts
+readableStreamValues`<T>(readable: ReadableStream<T>): AsyncIterableIterator<T>
+```
+
+`readableStreamValues` allow iteration of `ReadableStream` as an `AsyncIterableIterator`.
 
 ```ts
-const readableStream = new ReadableStream({
+const readable = new ReadableStream({
   start(controller) {
     controller.enqueue(1);
     controller.enqueue(2);
@@ -125,16 +142,22 @@ const readableStream = new ReadableStream({
   }
 });
 
-const iterable = readerValues(readableStream.getReader());
+const iterable = readableStreamValues(readable);
 
 for await (const value of iterable) {
   console.log(value); // Prints "1", "2", "3".
 }
 ```
 
+Note: The stream will be locked as soon as the iterable is created. When using iterating outside of for-loop, make sure to call `AsyncIterator.return` when the iteration is done to release the lock on the stream.
+
 Note: `[Symbol.asyncIterator]()` will not restart the reader and read from start of the stream. Reader is not restartable and streams are not seekable.
 
 ### Converting an `AsyncIterable`/`Iterable` to `ReadableStream`
+
+```ts
+readableStreamFrom<T>(anyIterable: AsyncIterable<T> | Iterable<T>): ReadableStream<T>
+```
 
 > Notes: this feature is part of [Streams Standard](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/from_static).
 

--- a/packages/integration-test/importDefault/observableValues.test.ts
+++ b/packages/integration-test/importDefault/observableValues.test.ts
@@ -1,0 +1,12 @@
+import { Observable, observableValues } from 'iter-fest';
+
+test('observableValues should work', async () => {
+  const observable = Observable.from([1, 2, 3]);
+  const values: number[] = [];
+
+  for await (const value of observableValues(observable)) {
+    values.push(value);
+  }
+
+  expect(values).toEqual([1, 2, 3]);
+});

--- a/packages/integration-test/importDefault/readableStreamValues.test.ts
+++ b/packages/integration-test/importDefault/readableStreamValues.test.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { readerValues } = require('iter-fest');
+import { readableStreamValues } from 'iter-fest';
 
-test('readerValues should work', async () => {
+test('readableStreamValues should work', async () => {
   const readableStream = new ReadableStream({
     start(controller) {
       controller.enqueue(1);
@@ -12,7 +11,7 @@ test('readerValues should work', async () => {
 
   const values = [];
 
-  for await (const value of readerValues(readableStream.getReader())) {
+  for await (const value of readableStreamValues(readableStream)) {
     values.push(value);
   }
 

--- a/packages/integration-test/importNamed/observableValues.test.ts
+++ b/packages/integration-test/importNamed/observableValues.test.ts
@@ -1,0 +1,13 @@
+import { Observable } from 'iter-fest/observable';
+import { observableValues } from 'iter-fest/observableValues';
+
+test('observableValues should work', async () => {
+  const observable = Observable.from([1, 2, 3]);
+  const values: number[] = [];
+
+  for await (const value of observableValues(observable)) {
+    values.push(value);
+  }
+
+  expect(values).toEqual([1, 2, 3]);
+});

--- a/packages/integration-test/importNamed/readableStreamValues.test.ts
+++ b/packages/integration-test/importNamed/readableStreamValues.test.ts
@@ -1,7 +1,6 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-const { readerValues } = require('iter-fest/readerValues');
+import { readableStreamValues } from 'iter-fest/readableStreamValues';
 
-test('readerValues should work', async () => {
+test('readableStreamValues should work', async () => {
   const readableStream = new ReadableStream({
     start(controller) {
       controller.enqueue(1);
@@ -12,7 +11,7 @@ test('readerValues should work', async () => {
 
   const values = [];
 
-  for await (const value of readerValues(readableStream.getReader())) {
+  for await (const value of readableStreamValues(readableStream)) {
     values.push(value);
   }
 

--- a/packages/integration-test/requireDefault/observableValues.test.ts
+++ b/packages/integration-test/requireDefault/observableValues.test.ts
@@ -1,0 +1,13 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { Observable, observableValues } = require('iter-fest');
+
+test('observableValues should work', async () => {
+  const observable = Observable.from([1, 2, 3]);
+  const values: number[] = [];
+
+  for await (const value of observableValues(observable)) {
+    values.push(value);
+  }
+
+  expect(values).toEqual([1, 2, 3]);
+});

--- a/packages/integration-test/requireDefault/readableStreamValues.test.ts
+++ b/packages/integration-test/requireDefault/readableStreamValues.test.ts
@@ -1,6 +1,7 @@
-import { readerValues } from 'iter-fest/readerValues';
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { readableStreamValues } = require('iter-fest');
 
-test('readerValues should work', async () => {
+test('readableStreamValues should work', async () => {
   const readableStream = new ReadableStream({
     start(controller) {
       controller.enqueue(1);
@@ -11,7 +12,7 @@ test('readerValues should work', async () => {
 
   const values = [];
 
-  for await (const value of readerValues(readableStream.getReader())) {
+  for await (const value of readableStreamValues(readableStream)) {
     values.push(value);
   }
 

--- a/packages/integration-test/requireNamed/observableValues.test.ts
+++ b/packages/integration-test/requireNamed/observableValues.test.ts
@@ -1,0 +1,14 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { Observable } = require('iter-fest/observable');
+const { observableValues } = require('iter-fest/observableValues');
+
+test('observableValues should work', async () => {
+  const observable = Observable.from([1, 2, 3]);
+  const values: number[] = [];
+
+  for await (const value of observableValues(observable)) {
+    values.push(value);
+  }
+
+  expect(values).toEqual([1, 2, 3]);
+});

--- a/packages/integration-test/requireNamed/readableStreamValues.ts
+++ b/packages/integration-test/requireNamed/readableStreamValues.ts
@@ -1,6 +1,7 @@
-import { readerValues } from 'iter-fest';
+/* eslint-disable @typescript-eslint/no-var-requires */
+const { readableStreamValues } = require('iter-fest/readableStreamValues');
 
-test('readerValues should work', async () => {
+test('readableStreamValues should work', async () => {
   const readableStream = new ReadableStream({
     start(controller) {
       controller.enqueue(1);
@@ -11,7 +12,7 @@ test('readerValues should work', async () => {
 
   const values = [];
 
-  for await (const value of readerValues(readableStream.getReader())) {
+  for await (const value of readableStreamValues(readableStream)) {
     values.push(value);
   }
 

--- a/packages/iter-fest/package.json
+++ b/packages/iter-fest/package.json
@@ -466,6 +466,16 @@
         "default": "./dist/iter-fest.observableSubscribeAsReadable.js"
       }
     },
+    "./observableValues": {
+      "import": {
+        "types": "./dist/iter-fest.observableValues.d.mts",
+        "default": "./dist/iter-fest.observableValues.mjs"
+      },
+      "require": {
+        "types": "./dist/iter-fest.observableValues.d.ts",
+        "default": "./dist/iter-fest.observableValues.js"
+      }
+    },
     "./readableStreamFrom": {
       "import": {
         "types": "./dist/iter-fest.readableStreamFrom.d.mts",

--- a/packages/iter-fest/package.json
+++ b/packages/iter-fest/package.json
@@ -476,14 +476,14 @@
         "default": "./dist/iter-fest.readableStreamFrom.js"
       }
     },
-    "./readerValues": {
+    "./readableStreamValues": {
       "import": {
-        "types": "./dist/iter-fest.readerValues.d.mts",
-        "default": "./dist/iter-fest.readerValues.mjs"
+        "types": "./dist/iter-fest.readableStreamValues.d.mts",
+        "default": "./dist/iter-fest.readableStreamValues.mjs"
       },
       "require": {
-        "types": "./dist/iter-fest.readerValues.d.ts",
-        "default": "./dist/iter-fest.readerValues.js"
+        "types": "./dist/iter-fest.readableStreamValues.d.ts",
+        "default": "./dist/iter-fest.readableStreamValues.js"
       }
     },
     "./symbolObservable": {

--- a/packages/iter-fest/src/asyncIteratorToArray.ts
+++ b/packages/iter-fest/src/asyncIteratorToArray.ts
@@ -1,17 +1,13 @@
 // @ts-expect-error core-js-pure is not typed.
 import toArray from 'core-js-pure/full/async-iterator/to-array';
 
-type AsyncIteratorLike<T> = Pick<AsyncIterator<T>, 'next'>;
-
 /**
  * When you have a non-infinite iterator which you wish to transform into an array, you can do so with the builtin toArray method.
- *
- * @param limit
  *
  * @return Returns an Array containing the values from the iterator.
  *
  * @link https://github.com/tc39/proposal-iterator-helpers/blob/main/README.md
  */
-export function asyncIteratorToArray<T>(asyncIteratorLike: AsyncIteratorLike<T>): Promise<T[]> {
+export function asyncIteratorToArray<T>(asyncIteratorLike: Pick<AsyncIterator<T>, 'next'>): Promise<T[]> {
   return toArray(asyncIteratorLike);
 }

--- a/packages/iter-fest/src/index.ts
+++ b/packages/iter-fest/src/index.ts
@@ -46,4 +46,4 @@ export * from './iteratorToString';
 export * from './observableFromAsync';
 export * from './observableSubscribeAsReadable';
 export * from './readableStreamFrom';
-export * from './readerValues';
+export * from './readableStreamValues';

--- a/packages/iter-fest/src/index.ts
+++ b/packages/iter-fest/src/index.ts
@@ -45,5 +45,6 @@ export * from './iteratorToSpliced';
 export * from './iteratorToString';
 export * from './observableFromAsync';
 export * from './observableSubscribeAsReadable';
+export * from './observableValues';
 export * from './readableStreamFrom';
 export * from './readableStreamValues';

--- a/packages/iter-fest/src/iteratorFrom.ts
+++ b/packages/iter-fest/src/iteratorFrom.ts
@@ -8,6 +8,6 @@ import from from 'core-js-pure/full/iterator/from';
  *
  * @link https://github.com/tc39/proposal-iterator-helpers/blob/main/README.md
  */
-export function iteratorFrom<T>(iteratorLike: Iterator<T>): Iterator<T> {
+export function iteratorFrom<T>(iteratorLike: Pick<Iterator<T>, 'next'>): Iterator<T> {
   return from(iteratorLike);
 }

--- a/packages/iter-fest/src/iteratorToArray.ts
+++ b/packages/iter-fest/src/iteratorToArray.ts
@@ -1,17 +1,13 @@
 // @ts-expect-error core-js-pure is not typed.
 import toArray from 'core-js-pure/full/iterator/to-array';
 
-type IteratorLike<T> = Pick<Iterator<T>, 'next'>;
-
 /**
  * When you have a non-infinite iterator which you wish to transform into an array, you can do so with the builtin toArray method.
- *
- * @param limit
  *
  * @return Returns an Array containing the values from the iterator.
  *
  * @link https://github.com/tc39/proposal-iterator-helpers/blob/main/README.md
  */
-export function iteratorToArray<T>(iteratorLike: IteratorLike<T>): T[] {
+export function iteratorToArray<T>(iteratorLike: Pick<Iterator<T>, 'next'>): T[] {
   return toArray(iteratorLike);
 }

--- a/packages/iter-fest/src/observableToAsyncIterableIteratorViaReadableStream.spec.ts
+++ b/packages/iter-fest/src/observableToAsyncIterableIteratorViaReadableStream.spec.ts
@@ -1,10 +1,10 @@
 import { Observable, type SubscriberFunction, type SubscriptionObserver } from './Observable';
 import { observableSubscribeAsReadable } from './observableSubscribeAsReadable';
 import type { JestMockOf } from './private/JestMockOf';
-import { readerValues } from './readerValues';
+import { readableStreamValues } from './readableStreamValues';
 
 function observableToAsyncIterableIteratorViaReadableStream<T>(observable: Observable<T>): AsyncIterableIterator<T> {
-  return readerValues(observableSubscribeAsReadable(observable).getReader());
+  return readableStreamValues(observableSubscribeAsReadable(observable));
 }
 
 describe('comprehensive', () => {

--- a/packages/iter-fest/src/observableValues.spec.ts
+++ b/packages/iter-fest/src/observableValues.spec.ts
@@ -1,11 +1,6 @@
 import { Observable, type SubscriberFunction, type SubscriptionObserver } from './Observable';
-import { observableSubscribeAsReadable } from './observableSubscribeAsReadable';
+import { observableValues } from './observableValues';
 import type { JestMockOf } from './private/JestMockOf';
-import { readableStreamValues } from './readableStreamValues';
-
-function observableToAsyncIterableIteratorViaReadableStream<T>(observable: Observable<T>): AsyncIterableIterator<T> {
-  return readableStreamValues(observableSubscribeAsReadable(observable));
-}
 
 describe('comprehensive', () => {
   describe('step-by-step', () => {
@@ -24,7 +19,7 @@ describe('comprehensive', () => {
       });
 
       observable = new Observable(subscriberFunction);
-      iterator = observableToAsyncIterableIteratorViaReadableStream(observable);
+      iterator = observableValues(observable);
     });
 
     describe('when iterator.next() is called', () => {
@@ -63,7 +58,7 @@ describe('comprehensive', () => {
 
     beforeEach(() => {
       observable = Observable.from([1, 2, 3]);
-      iterator = observableToAsyncIterableIteratorViaReadableStream(observable);
+      iterator = observableValues(observable);
     });
 
     describe('when iterate', () => {
@@ -96,7 +91,7 @@ describe('comprehensive', () => {
     const values: number[] = [];
 
     const promise = (async function () {
-      const iterator = observableToAsyncIterableIteratorViaReadableStream<number>(observable);
+      const iterator = observableValues<number>(observable);
 
       for await (const value of iterator) {
         values.push(value);

--- a/packages/iter-fest/src/observableValues.ts
+++ b/packages/iter-fest/src/observableValues.ts
@@ -1,0 +1,29 @@
+import type { Observable } from './Observable';
+import { observableSubscribeAsReadable } from './observableSubscribeAsReadable';
+import { readableStreamValues } from './readableStreamValues';
+
+export function observableValues<T>(observable: Observable<T>): AsyncIterableIterator<T> {
+  const readable = observableSubscribeAsReadable(observable);
+  const iterable = readableStreamValues(readable);
+
+  const cancellableIterable: AsyncIterableIterator<T> = {
+    [Symbol.asyncIterator]() {
+      return cancellableIterable;
+    },
+    next() {
+      return iterable.next();
+    },
+    return() {
+      try {
+        return iterable.return?.() ?? Promise.resolve({ done: true, value: undefined });
+      } finally {
+        readable.cancel();
+      }
+    },
+    throw(error) {
+      return iterable.throw?.(error) ?? Promise.resolve({ done: true, value: undefined });
+    }
+  };
+
+  return cancellableIterable;
+}

--- a/packages/iter-fest/src/readableStreamValues.ts
+++ b/packages/iter-fest/src/readableStreamValues.ts
@@ -1,4 +1,6 @@
-export function readerValues<T>(reader: ReadableStreamDefaultReader<T>): AsyncIterableIterator<T> {
+export function readableStreamValues<T>(readable: ReadableStream<T>): AsyncIterableIterator<T> {
+  const reader = readable.getReader();
+
   const iterable: AsyncIterableIterator<T> = {
     [Symbol.asyncIterator]() {
       return iterable;
@@ -13,8 +15,8 @@ export function readerValues<T>(reader: ReadableStreamDefaultReader<T>): AsyncIt
       return { value: result.value };
     },
     async return() {
-      // Throw inside for-loop is return().
-      reader.cancel();
+      // Break/throw inside for-loop will trigger return().
+      reader.releaseLock();
 
       return { done: true, value: undefined };
     }

--- a/packages/iter-fest/tsup.config.ts
+++ b/packages/iter-fest/tsup.config.ts
@@ -51,6 +51,7 @@ export default defineConfig([
       'iter-fest.observable': './src/Observable.ts',
       'iter-fest.observableFromAsync': './src/observableFromAsync.ts',
       'iter-fest.observableSubscribeAsReadable': './src/observableSubscribeAsReadable.ts',
+      'iter-fest.observableValues': './src/observableValues.ts',
       'iter-fest.readableStreamFrom': './src/readableStreamFrom.ts',
       'iter-fest.readableStreamValues': './src/readableStreamValues.ts',
       'iter-fest.symbolObservable': './src/SymbolObservable.ts'

--- a/packages/iter-fest/tsup.config.ts
+++ b/packages/iter-fest/tsup.config.ts
@@ -52,7 +52,7 @@ export default defineConfig([
       'iter-fest.observableFromAsync': './src/observableFromAsync.ts',
       'iter-fest.observableSubscribeAsReadable': './src/observableSubscribeAsReadable.ts',
       'iter-fest.readableStreamFrom': './src/readableStreamFrom.ts',
-      'iter-fest.readerValues': './src/readerValues.ts',
+      'iter-fest.readableStreamValues': './src/readableStreamValues.ts',
       'iter-fest.symbolObservable': './src/SymbolObservable.ts'
     },
     format: ['cjs', 'esm'],


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Added

- Added `readableStreamValues` in PR [#12](https://github.com/compulim/iter-fest/pull/12), [#14](https://github.com/compulim/iter-fest/pull/14), and [#30](https://github.com/compulim/iter-fest/pull/30)
- Added `observableValues` in PR [#30](https://github.com/compulim/iter-fest/pull/30)

## Specific changes

> Please list each individual specific change in this pull request.

- Renamed `readerValues` to `readableStreamValues`
   - When the iterator is returned, it will release the lock on readable, instead of cancelling
- Added `observableValues`
   - `readableStreamValues` no longer cancel out on return, thus, there are no signals on `ReadableStream` for unsubscribing from the observable
   - The new `observableValues` are using `ReadableStream` for internal buffer
- Updated `README.md` 