### PR TITLE
Clean up after porting to mocha

### DIFF
--- a/.eslintrc.mocha.yml
+++ b/.eslintrc.mocha.yml
@@ -1,0 +1,10 @@
+env:
+  commonjs: true
+  es2021: true
+  es2022: true
+  mocha: true
+rules:
+  # Disable for convenience
+  react/display-name: off
+  # Disable for convenience
+  react/prop-types: off

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed ESM imports under Node.js, in PR [#37](https://github.com/compulim/iter-fest/pull/37)
+- Fixed ESM imports under Node.js, in PR [#37](https://github.com/compulim/iter-fest/pull/37) and [#38](https://github.com/compulim/iter-fest/pull/38)
 
 ### Added
 

--- a/packages/integration-test/.eslintrc.yml
+++ b/packages/integration-test/.eslintrc.yml
@@ -1,3 +1,3 @@
 extends:
+  - ../../.eslintrc.mocha.yml
   - ../../.eslintrc.react.yml
-  - ../../.eslintrc.jest.yml

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -10,8 +10,7 @@
     "bump:prod": "PACKAGES_TO_BUMP=$(cat package.json | jq -r '(.pinDependencies // {}) as $P | (.localPeerDependencies // {}) as $L | (.dependencies // {}) | to_entries | map(select(.key as $K | $L | has($K) | not)) | map(.key + \"@\" + ($P[.key] // [\"latest\"])[0]) | join(\" \")') && [ ! -z \"$PACKAGES_TO_BUMP\" ] && npm install $PACKAGES_TO_BUMP || true",
     "precommit": "eslint --ext .js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts ./",
     "switch": "cat package.json | jq --arg SWITCH_NAME $SWITCH_NAME -r '(.[\"switch:\" + $SWITCH_NAME] // {}) as $TEMPLATE | .devDependencies += ($TEMPLATE.devDependencies // {}) | .dependencies += ($TEMPLATE.dependencies // {})' | tee ./package.json.tmp && mv ./package.json.tmp ./package.json",
-    "test": "mocha --recursive",
-    "test:jest": "jest"
+    "test": "mocha --recursive"
   },
   "author": "William Wong (https://github.com/compulim)",
   "license": "MIT",

--- a/packages/integration-test/tsconfig.json
+++ b/packages/integration-test/tsconfig.json
@@ -1,7 +1,0 @@
-// This configuration file is for VSCode only.
-{
-  "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
-  }
-}


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Fixed ESM imports under Node.js, in PR [#37](https://github.com/compulim/iter-fest/pull/37) and [#38](https://github.com/compulim/iter-fest/pull/38)

## Specific changes

> Please list each individual specific change in this pull request.

- Clean up after porting to mocha